### PR TITLE
Follow ups: deshare eachKey, eachVal validations between fields of same type, remove dup code

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -476,8 +476,6 @@ func Validate_CSIPersistentVolumeSource(in *v1.CSIPersistentVolumeSource, fldPat
 
 	// VolumeAttributes
 	for key, val := range in.VolumeAttributes {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// ControllerPublishSecretRef
@@ -517,8 +515,6 @@ func Validate_CSIVolumeSource(in *v1.CSIVolumeSource, fldPath *field.Path) (errs
 
 	// VolumeAttributes
 	for key, val := range in.VolumeAttributes {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// NodePublishSecretRef
@@ -550,8 +546,6 @@ func Validate_Capability(in *v1.Capability, fldPath *field.Path) (errs field.Err
 func Validate_CephFSPersistentVolumeSource(in *v1.CephFSPersistentVolumeSource, fldPath *field.Path) (errs field.ErrorList) {
 	// Monitors
 	for i, val := range in.Monitors {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Path
@@ -573,8 +567,6 @@ func Validate_CephFSPersistentVolumeSource(in *v1.CephFSPersistentVolumeSource, 
 func Validate_CephFSVolumeSource(in *v1.CephFSVolumeSource, fldPath *field.Path) (errs field.ErrorList) {
 	// Monitors
 	for i, val := range in.Monitors {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Path
@@ -713,8 +705,6 @@ func Validate_ConfigMap(in *v1.ConfigMap, fldPath *field.Path) (errs field.Error
 
 	// Data
 	for key, val := range in.Data {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// BinaryData
@@ -811,14 +801,10 @@ func Validate_Container(in *v1.Container, fldPath *field.Path) (errs field.Error
 
 	// Command
 	for i, val := range in.Command {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Args
 	for i, val := range in.Args {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// WorkingDir
@@ -906,8 +892,6 @@ func Validate_Container(in *v1.Container, fldPath *field.Path) (errs field.Error
 func Validate_ContainerImage(in *v1.ContainerImage, fldPath *field.Path) (errs field.ErrorList) {
 	// Names
 	for i, val := range in.Names {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// SizeBytes
@@ -1255,14 +1239,10 @@ func Validate_EphemeralContainerCommon(in *v1.EphemeralContainerCommon, fldPath 
 
 	// Command
 	for i, val := range in.Command {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Args
 	for i, val := range in.Args {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// WorkingDir
@@ -1440,8 +1420,6 @@ func Validate_EventSource(in *v1.EventSource, fldPath *field.Path) (errs field.E
 func Validate_ExecAction(in *v1.ExecAction, fldPath *field.Path) (errs field.ErrorList) {
 	// Command
 	for i, val := range in.Command {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -1450,8 +1428,6 @@ func Validate_ExecAction(in *v1.ExecAction, fldPath *field.Path) (errs field.Err
 func Validate_FCVolumeSource(in *v1.FCVolumeSource, fldPath *field.Path) (errs field.ErrorList) {
 	// TargetWWNs
 	for i, val := range in.TargetWWNs {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Lun
@@ -1462,8 +1438,6 @@ func Validate_FCVolumeSource(in *v1.FCVolumeSource, fldPath *field.Path) (errs f
 
 	// WWIDs
 	for i, val := range in.WWIDs {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -1487,8 +1461,6 @@ func Validate_FlexPersistentVolumeSource(in *v1.FlexPersistentVolumeSource, fldP
 
 	// Options
 	for key, val := range in.Options {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	return errs
@@ -1508,8 +1480,6 @@ func Validate_FlexVolumeSource(in *v1.FlexVolumeSource, fldPath *field.Path) (er
 
 	// Options
 	for key, val := range in.Options {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	return errs
@@ -1608,8 +1578,6 @@ func Validate_HostAlias(in *v1.HostAlias, fldPath *field.Path) (errs field.Error
 
 	// Hostnames
 	for i, val := range in.Hostnames {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -1659,8 +1627,6 @@ func Validate_ISCSIPersistentVolumeSource(in *v1.ISCSIPersistentVolumeSource, fl
 
 	// Portals
 	for i, val := range in.Portals {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// DiscoveryCHAPAuth
@@ -1692,8 +1658,6 @@ func Validate_ISCSIVolumeSource(in *v1.ISCSIVolumeSource, fldPath *field.Path) (
 
 	// Portals
 	for i, val := range in.Portals {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// DiscoveryCHAPAuth
@@ -2167,8 +2131,6 @@ func Validate_NodeSelectorRequirement(in *v1.NodeSelectorRequirement, fldPath *f
 
 	// Values
 	for i, val := range in.Values {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -2193,8 +2155,6 @@ func Validate_NodeSpec(in *v1.NodeSpec, fldPath *field.Path) (errs field.ErrorLi
 
 	// PodCIDRs
 	for i, val := range in.PodCIDRs {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// ProviderID
@@ -2665,8 +2625,6 @@ func Validate_PersistentVolumeSpec(in *v1.PersistentVolumeSpec, fldPath *field.P
 
 	// MountOptions
 	for i, val := range in.MountOptions {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// VolumeMode
@@ -2746,8 +2704,6 @@ func Validate_PodAffinityTerm(in *v1.PodAffinityTerm, fldPath *field.Path) (errs
 
 	// Namespaces
 	for i, val := range in.Namespaces {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// TopologyKey
@@ -2759,14 +2715,10 @@ func Validate_PodAffinityTerm(in *v1.PodAffinityTerm, fldPath *field.Path) (errs
 
 	// MatchLabelKeys
 	for i, val := range in.MatchLabelKeys {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// MismatchLabelKeys
 	for i, val := range in.MismatchLabelKeys {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -2830,14 +2782,10 @@ func Validate_PodConditionType(in *v1.PodConditionType, fldPath *field.Path) (er
 func Validate_PodDNSConfig(in *v1.PodDNSConfig, fldPath *field.Path) (errs field.ErrorList) {
 	// Nameservers
 	for i, val := range in.Nameservers {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Searches
 	for i, val := range in.Searches {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Options
@@ -2872,8 +2820,6 @@ func Validate_PodExecOptions(in *v1.PodExecOptions, fldPath *field.Path) (errs f
 
 	// Command
 	for i, val := range in.Command {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -3086,8 +3032,6 @@ func Validate_PodSpec(in *v1.PodSpec, fldPath *field.Path) (errs field.ErrorList
 
 	// NodeSelector
 	for key, val := range in.NodeSelector {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// ServiceAccountName
@@ -3423,8 +3367,6 @@ func Validate_QuobyteVolumeSource(in *v1.QuobyteVolumeSource, fldPath *field.Pat
 func Validate_RBDPersistentVolumeSource(in *v1.RBDPersistentVolumeSource, fldPath *field.Path) (errs field.ErrorList) {
 	// CephMonitors
 	for i, val := range in.CephMonitors {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// RBDImage
@@ -3450,8 +3392,6 @@ func Validate_RBDPersistentVolumeSource(in *v1.RBDPersistentVolumeSource, fldPat
 func Validate_RBDVolumeSource(in *v1.RBDVolumeSource, fldPath *field.Path) (errs field.ErrorList) {
 	// CephMonitors
 	for i, val := range in.CephMonitors {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// RBDImage
@@ -3553,8 +3493,6 @@ func Validate_ReplicationControllerSpec(in *v1.ReplicationControllerSpec, fldPat
 
 	// Selector
 	for key, val := range in.Selector {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// Template
@@ -3782,8 +3720,6 @@ func Validate_ScopedResourceSelectorRequirement(in *v1.ScopedResourceSelectorReq
 
 	// Values
 	for i, val := range in.Values {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs
@@ -3817,8 +3753,6 @@ func Validate_Secret(in *v1.Secret, fldPath *field.Path) (errs field.ErrorList) 
 
 	// StringData
 	for key, val := range in.StringData {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// Type
@@ -4084,16 +4018,12 @@ func Validate_ServiceSpec(in *v1.ServiceSpec, fldPath *field.Path) (errs field.E
 
 	// Selector
 	for key, val := range in.Selector {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// ClusterIP
 
 	// ClusterIPs
 	for i, val := range in.ClusterIPs {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Type
@@ -4101,8 +4031,6 @@ func Validate_ServiceSpec(in *v1.ServiceSpec, fldPath *field.Path) (errs field.E
 
 	// ExternalIPs
 	for i, val := range in.ExternalIPs {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// SessionAffinity
@@ -4112,8 +4040,6 @@ func Validate_ServiceSpec(in *v1.ServiceSpec, fldPath *field.Path) (errs field.E
 
 	// LoadBalancerSourceRanges
 	for i, val := range in.LoadBalancerSourceRanges {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// ExternalName
@@ -4315,8 +4241,6 @@ func Validate_TopologySpreadConstraint(in *v1.TopologySpreadConstraint, fldPath 
 
 	// MatchLabelKeys
 	for i, val := range in.MatchLabelKeys {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/zz_generated.validations.go
@@ -55,69 +55,43 @@ func Validate_T1(in *T1, fldPath *field.Path) (errs field.ErrorList) {
 	// MSS
 	errs = append(errs, validate.FixedResult(fldPath.Child("mss"), in.MSS, true, "field T1.MSS")...)
 	for key, val := range in.MSS {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// MSPS
 	errs = append(errs, validate.FixedResult(fldPath.Child("msps"), in.MSPS, true, "field T1.MSPS")...)
 	for key, val := range in.MSPS {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSPS[*]")...)
-		if val != nil {
-			errs = append(errs, validate.FixedResult(fldPath.Key(key), *val, true, "val T1.MSPS[*]")...)
-		}
 	}
 
 	// MPSS
 	errs = append(errs, validate.FixedResult(fldPath.Child("mpss"), in.MPSS, true, "field T1.MPSS")...)
 	for key, val := range in.MPSS {
-		if key != nil {
-			errs = append(errs, validate.FixedResult(fldPath, *key, true, "key T1.MPSS[*]")...)
-		}
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MPSS[*]")...)
 	}
 
 	// MPSPS
 	errs = append(errs, validate.FixedResult(fldPath.Child("mpsps"), in.MPSPS, true, "field T1.MPSPS")...)
 	for key, val := range in.MPSPS {
-		if key != nil {
-			errs = append(errs, validate.FixedResult(fldPath, *key, true, "key T1.MPSPS[*]")...)
-		}
-		if val != nil {
-			errs = append(errs, validate.FixedResult(fldPath.Key(key), *val, true, "val T1.MPSPS[*]")...)
-		}
 	}
 
 	// MST2
 	errs = append(errs, validate.FixedResult(fldPath.Child("mst2"), in.MST2, true, "field T1.MST2")...)
 	for key, val := range in.MST2 {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSS[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSS[*]")...)
 	}
 
 	// MSPT2
 	errs = append(errs, validate.FixedResult(fldPath.Child("mspt2"), in.MSPT2, true, "field T1.MSPT2")...)
 	for key, val := range in.MSPT2 {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSPS[*]")...)
-		if val != nil {
-			errs = append(errs, validate.FixedResult(fldPath.Key(key), *val, true, "val T1.MSPS[*]")...)
-		}
 	}
 
 	// MSE1
 	errs = append(errs, validate.FixedResult(fldPath.Child("mse1"), in.MSE1, true, "field T1.MSE1")...)
 	for key, val := range in.MSE1 {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.MSE1[*]")...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.MSE1[*]")...)
 		errs = append(errs, Validate_E1(&val, fldPath.Key(key))...)
 	}
 
 	// ME1S
 	errs = append(errs, validate.FixedResult(fldPath.Child("<unknown-json-name>"), in.ME1S, true, "field T1.ME1S")...)
 	for key, val := range in.ME1S {
-		errs = append(errs, validate.FixedResult(fldPath, key, true, "key T1.ME1S[*]")...)
 		errs = append(errs, Validate_E1(&key, fldPath)...)
-		errs = append(errs, validate.FixedResult(fldPath.Key(key), val, true, "val T1.ME1S[*]")...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/doc.go
@@ -24,11 +24,35 @@ type T1 struct {
 	// +validateTrue="field T1.S"
 	S  string `json:"s"`
 	T2 T2     `json:"t2"`
+	T3 T3     `json:"t3"`
+	T4 T4     `json:"t4"`
+	T5 T5     `json:"t5"`
+	T6 T6     `json:"t6"`
 }
 
 type T2 struct {
 	// +validateTrue="field T2.S"
 	S string `json:"s"`
+}
+
+// This type should not be generated. It has no validations.
+type T3 struct {
+	S string `json:"s"`
+}
+
+// This type should be generated, it has a child type that has validations.
+type T4 struct {
+	t2 T2 `json:"t2"`
+}
+
+// This type should be generated, it has a map value type that has validations.
+type T5 struct {
+	t2 map[string]T2 `json:"t2"`
+}
+
+// This type should be generated, it has a list items that has validations.
+type T6 struct {
+	t2 []T2 `json:"t2"`
 }
 
 type private struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/zz_generated.validations.go
@@ -52,12 +52,55 @@ func Validate_T1(in *T1, fldPath *field.Path) (errs field.ErrorList) {
 	// T2
 	errs = append(errs, Validate_T2(&in.T2, fldPath.Child("t2"))...)
 
+	// T3
+	errs = append(errs, Validate_T3(&in.T3, fldPath.Child("t3"))...)
+
+	// T4
+	errs = append(errs, Validate_T4(&in.T4, fldPath.Child("t4"))...)
+
+	// T5
+	errs = append(errs, Validate_T5(&in.T5, fldPath.Child("t5"))...)
+
+	// T6
+	errs = append(errs, Validate_T6(&in.T6, fldPath.Child("t6"))...)
+
 	return errs
 }
 
 func Validate_T2(in *T2, fldPath *field.Path) (errs field.ErrorList) {
 	// S
 	errs = append(errs, validate.FixedResult(fldPath.Child("s"), in.S, true, "field T2.S")...)
+
+	return errs
+}
+
+func Validate_T3(in *T3, fldPath *field.Path) (errs field.ErrorList) {
+	// S
+
+	return errs
+}
+
+func Validate_T4(in *T4, fldPath *field.Path) (errs field.ErrorList) {
+	// t2
+	errs = append(errs, Validate_T2(&in.t2, fldPath.Child("t2"))...)
+
+	return errs
+}
+
+func Validate_T5(in *T5, fldPath *field.Path) (errs field.ErrorList) {
+	// t2
+	for key, val := range in.t2 {
+		errs = append(errs, Validate_T2(&val, fldPath.Key(key))...)
+	}
+
+	return errs
+}
+
+func Validate_T6(in *T6, fldPath *field.Path) (errs field.ErrorList) {
+	// t2
+	for i, val := range in.t2 {
+		errs = append(errs, Validate_T2(&val, fldPath.Index(i))...)
+	}
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/doc.go
@@ -40,6 +40,9 @@ type T1 struct {
 	// +eachVal=+validateTrue="field T1.LPT2[*]"
 	// +eachVal=+required
 	LPT2 []*T2 `json:"lpt2"`
+
+	// +validateTrue="field Z"
+	Z []string `json:"z"` // Should not have any eachKey, eachVal tags applied
 }
 
 // +validateTrue="type T2"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/zz_generated.validations.go
@@ -50,24 +50,16 @@ func Validate_T1(in *T1, fldPath *field.Path) (errs field.ErrorList) {
 	// LS
 	errs = append(errs, validate.FixedResult(fldPath.Child("ls"), in.LS, true, "field T1.LS")...)
 	for i, val := range in.LS {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// LPS
 	errs = append(errs, validate.FixedResult(fldPath.Child("lps"), in.LPS, true, "field T1.LPS")...)
 	for i, val := range in.LPS {
-		if val != nil {
-			errs = append(errs, validate.FixedResult(fldPath.Index(i), *val, true, "field T1.LPS[*]")...)
-		}
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// LT2
 	errs = append(errs, validate.FixedResult(fldPath.Child("lt2"), in.LT2, true, "field T1.LT2")...)
 	for i, val := range in.LT2 {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LT2[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 		errs = append(errs, Validate_T2(&val, fldPath.Index(i))...)
 	}
 
@@ -75,12 +67,13 @@ func Validate_T1(in *T1, fldPath *field.Path) (errs field.ErrorList) {
 	errs = append(errs, validate.FixedResult(fldPath.Child("lpt2"), in.LPT2, true, "field T1.LPT2")...)
 	for i, val := range in.LPT2 {
 		if val != nil {
-			errs = append(errs, validate.FixedResult(fldPath.Index(i), *val, true, "field T1.LPT2[*]")...)
-		}
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
-		if val != nil {
 			errs = append(errs, Validate_T2(val, fldPath.Index(i))...)
 		}
+	}
+
+	// Z
+	errs = append(errs, validate.FixedResult(fldPath.Child("z"), in.Z, true, "field Z")...)
+	for i, val := range in.Z {
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
@@ -220,11 +220,6 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 			return cmp.Compare(a.Name.String(), b.Name.String())
 		})
 
-		// Deterministic ordering helps in logs and debugging.
-		slices.SortFunc(rootTypes, func(a, b *types.Type) int {
-			return cmp.Compare(a.Name.String(), b.Name.String())
-		})
-
 		for _, t := range rootTypes {
 			if _, ok := typeNodes[t]; ok {
 				continue // already did this one

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.validations.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.validations.go
@@ -75,8 +75,6 @@ func Validate_Fischer(in *Fischer, fldPath *field.Path) (errs field.ErrorList) {
 
 	// DisallowedFlunders
 	for i, val := range in.DisallowedFlunders {
-		errs = append(errs, validate.FixedResult(fldPath.Index(i), val, true, "field T1.LS[*]")...)
-		errs = append(errs, validate.Required(fldPath.Index(i), val)...)
 	}
 
 	// Reference


### PR DESCRIPTION
@thockin https://github.com/jpbetz/kubernetes/commit/e4a3429b6144f90e2f22fd99f7c5986a862ff7db could use your eyes.  The problem was simply that the typeNode for types like `string[]` were being written to `typeNodes[]` multiple times, each with different `eachKey` and `eachVal` validations, resulting in the last-writer's value (written to `typesNode`) being used in all generation for that type.

I hacked up a quick fix that moved `eachKey`, `eachVal` propagation onto the stack.  Happy to defer to any approach you'd prefer here, I just wanted to illustrate the bug I found and propose at least one possible fix.