### PR TITLE
Document the typdef-to-typedef behavior

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/aliases/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/aliases/doc.go
@@ -26,7 +26,10 @@ type E1 string
 type E2 int
 
 // +validateTrue="type E3"
-type E3 T2
+type E3 E1
+
+// +validateTrue="type E4"
+type E4 T2
 
 // +validateTrue="type T1"
 type T1 struct {
@@ -46,6 +49,11 @@ type T1 struct {
 	E3 E3 `json:"e3"`
 	// +validateTrue="field T1.PE3"
 	PE3 *E3 `json:"pe3"`
+
+	// +validateTrue="field T1.E4"
+	E4 E4 `json:"e4"`
+	// +validateTrue="field T1.PE4"
+	PE4 *E4 `json:"pe4"`
 
 	// +validateTrue="field T1.T2"
 	T2 T2 `json:"t2"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/aliases/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/aliases/zz_generated.validations.go
@@ -55,6 +55,11 @@ func Validate_E2(in *E2, fldPath *field.Path) (errs field.ErrorList) {
 
 func Validate_E3(in *E3, fldPath *field.Path) (errs field.ErrorList) {
 	errs = append(errs, validate.FixedResult(fldPath, in, true, "type E3")...)
+	return errs
+}
+
+func Validate_E4(in *E4, fldPath *field.Path) (errs field.ErrorList) {
+	errs = append(errs, validate.FixedResult(fldPath, in, true, "type E4")...)
 	// S
 	errs = append(errs, validate.FixedResult(fldPath.Child("s"), in.S, true, "field T2.S")...)
 
@@ -99,6 +104,18 @@ func Validate_T1(in *T1, fldPath *field.Path) (errs field.ErrorList) {
 	}
 	if in.PE3 != nil {
 		errs = append(errs, Validate_E3(in.PE3, fldPath.Child("pe3"))...)
+	}
+
+	// E4
+	errs = append(errs, validate.FixedResult(fldPath.Child("e4"), in.E4, true, "field T1.E4")...)
+	errs = append(errs, Validate_E4(&in.E4, fldPath.Child("e4"))...)
+
+	// PE4
+	if in.PE4 != nil {
+		errs = append(errs, validate.FixedResult(fldPath.Child("pe4"), *in.PE4, true, "field T1.PE4")...)
+	}
+	if in.PE4 != nil {
+		errs = append(errs, Validate_E4(in.PE4, fldPath.Child("pe4"))...)
 	}
 
 	// T2


### PR DESCRIPTION
I'll still look for a way to do what we want, but it seems like Go doesn't want me to.  Given:

```
type T1 string
type T2 T1
```

T1 and T2 "are unrelated" in the type system.  It's false to think of T2 and derived form of T1.  It's not.  "Go doesn't have inheritance".

