### PR TITLE
Make `validation-gen --docs` print known tags

### DIFF
--- a/TODO.validation-gen
+++ b/TODO.validation-gen
@@ -72,6 +72,10 @@
 - "inner" validation
 - Generator unit tests need updating
 - How to handle feature gates and options structs
+- rename or eliminate the peer-dirs flag
+
+
+Later:
 - Try to link typedef-of-typedef to chain validations?
   ```
   Get pos in walkType

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -18,13 +18,21 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
+	"cmp"
 	"flag"
 	"fmt"
+	"os"
+	"slices"
+	"strings"
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
+	"k8s.io/gengo/v2/namer"
+	"k8s.io/gengo/v2/types"
 	"k8s.io/klog/v2"
 )
 
@@ -39,6 +47,11 @@ func main() {
 
 	if err := args.Validate(); err != nil {
 		klog.Fatalf("Error: %v", err)
+	}
+
+	if args.PrintDocs {
+		printDocs()
+		os.Exit(0)
 	}
 
 	myTargets := func(context *generator.Context) []generator.Target {
@@ -62,6 +75,7 @@ type Args struct {
 	OutputFile    string
 	ExtraPeerDirs []string // Always consider these as last-ditch possibilities for validations.
 	GoHeaderFile  string
+	PrintDocs     bool
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -69,9 +83,11 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&args.OutputFile, "output-file", "generated.validations.go",
 		"the name of the file to be generated")
 	fs.StringSliceVar(&args.ExtraPeerDirs, "extra-peer-dirs", args.ExtraPeerDirs, //FIXME: need this?
-		"Comma-separated list of import paths which are considered, after tag-specified peers, for validations.")
+		"comma-separated list of import paths which are considered, after tag-specified peers, for validations")
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
+	fs.BoolVar(&args.PrintDocs, "docs", false,
+		"print documentation for supported declarative validations, and then exit")
 }
 
 // Validate checks the given arguments.
@@ -81,4 +97,60 @@ func (args *Args) Validate() error {
 	}
 
 	return nil
+}
+
+var friendlyContextNames = map[validators.TagContext]string{
+	validators.TagContextType:  "type definitions",
+	validators.TagContextField: "field definitions (including map keys and map/slice values)",
+}
+
+func printDocs() {
+	// We need a fake context to init the validator plugins.
+	c := &generator.Context{
+		Namers:    namer.NameSystems{},
+		Universe:  types.Universe{},
+		FileTypes: map[string]generator.FileType{},
+	}
+
+	// This gets a composite validator which aggregates the many plugins.
+	validator := validators.NewValidator(c, nil, nil)
+
+	docs := builtinTagDocs()
+	docs = append(docs, validator.Docs()...)
+	slices.SortFunc(docs, func(a, b validators.TagDoc) int {
+		return cmp.Compare(a.Tag, b.Tag)
+	})
+
+	for _, doc := range docs {
+		fmt.Printf("Tag: +%s\n", clean(doc.Tag))
+		fmt.Printf("Description: %s\n", clean(doc.Description))
+		fmt.Printf("Attach to:\n")
+		for _, c := range doc.Contexts {
+			friendly, found := friendlyContextNames[c]
+			if !found {
+				friendly = fmt.Sprintf("<unknown tag context: %q>", c)
+			}
+			fmt.Printf("    - %s\n", friendly)
+		}
+		fmt.Printf("Tag value(s):\n")
+		for _, p := range doc.Payloads {
+			fmt.Printf("    %s:  %s\n", clean(p.Description), indent(clean(p.Docs), "      "))
+		}
+		fmt.Printf("\n")
+	}
+}
+
+func clean(in string) string {
+	return strings.TrimSpace(in)
+}
+
+func indent(in string, indent string) string {
+	buf := bytes.Buffer{}
+	for _, r := range in {
+		buf.WriteRune(r)
+		if r == '\n' {
+			buf.WriteString(indent)
+		}
+	}
+	return buf.String()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -304,7 +304,7 @@ func builtinTagDocs() []validators.TagDoc {
 		Tag:         eachKeyTag,
 		Description: "Declares a validation for map keys.",
 		Contexts:    []validators.TagContext{validators.TagContextType, validators.TagContextField},
-		Payloads: []validators.TagPayload{{
+		Payloads: []validators.TagPayloadDoc{{
 			Description: "<validation-tag>",
 			Docs:        "This tag will be evaluated for each key of a map.",
 		}},
@@ -312,7 +312,7 @@ func builtinTagDocs() []validators.TagDoc {
 		Tag:         eachValTag,
 		Description: "Declares a validation for map and slice values.",
 		Contexts:    []validators.TagContext{validators.TagContextType, validators.TagContextField},
-		Payloads: []validators.TagPayload{{
+		Payloads: []validators.TagPayloadDoc{{
 			Description: "<validation-tag>",
 			Docs:        "This tag will be evaluated for each value of a map or slice.",
 		}},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -298,6 +298,27 @@ const (
 	eachValTag = "eachVal"
 )
 
+// builtinTagDocs returns information about the hard-coded tags.
+func builtinTagDocs() []validators.TagDoc {
+	return []validators.TagDoc{{
+		Tag:         eachKeyTag,
+		Description: "Declares a validation for map keys.",
+		Contexts:    []validators.TagContext{validators.TagContextType, validators.TagContextField},
+		Payloads: []validators.TagPayload{{
+			Description: "<validation-tag>",
+			Docs:        "This tag will be evaluated for each key of a map.",
+		}},
+	}, {
+		Tag:         eachValTag,
+		Description: "Declares a validation for map and slice values.",
+		Contexts:    []validators.TagContext{validators.TagContextType, validators.TagContextField},
+		Payloads: []validators.TagPayload{{
+			Description: "<validation-tag>",
+			Docs:        "This tag will be evaluated for each value of a map or slice.",
+		}},
+	}}
+}
+
 // DiscoverType walks the given type recursively, building a type-graph in this
 // typeDiscoverer.  If this is called multiple times for different types, the
 // multiple graphs will be stored, and where types overlap, they will be

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
@@ -49,6 +49,15 @@ func (c *enumDeclarativeValidator) ExtractValidations(t *types.Type, comments []
 	return result, nil
 }
 
+func (enumDeclarativeValidator) Docs() []TagDoc {
+	return []TagDoc{{
+		Tag:         tagEnumType,
+		Description: "Indicates that a string type is an enum. All const values of this type are considered values in the enum.",
+		Contexts:    []TagContext{TagContextType},
+		Payloads:    nil,
+	}}
+}
+
 func (et *enumType) ValueArgs() []any {
 	var values []any
 	for _, value := range et.Symbols() {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/openapi.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/openapi.go
@@ -69,7 +69,7 @@ func (openAPIDeclarativeValidator) Docs() []TagDoc {
 		Tag:         formatTagName,
 		Description: "Indicates that a string field has a particular format.",
 		Contexts:    []TagContext{TagContextType, TagContextField},
-		Payloads: []TagPayload{{
+		Payloads: []TagPayloadDoc{{
 			Description: "ip",
 			Docs:        "This field holds an IP address value, either IPv4 or IPv6.",
 		}, {
@@ -80,7 +80,7 @@ func (openAPIDeclarativeValidator) Docs() []TagDoc {
 		Tag:         maxLengthTagName,
 		Description: "Indicates that a string field has a limit on its length.",
 		Contexts:    []TagContext{TagContextType, TagContextField},
-		Payloads: []TagPayload{{
+		Payloads: []TagPayloadDoc{{
 			Description: "<non-negative integer>",
 			Docs:        "This field must be no more than X characters long.",
 		}},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/openapi.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/openapi.go
@@ -33,7 +33,7 @@ func InitOpenAPIDeclarativeValidator(c *generator.Context) DeclarativeValidator 
 type openAPIDeclarativeValidator struct{}
 
 const (
-	markerPrefix     = "+k8s:validation:"
+	markerPrefix     = "k8s:validation:"
 	formatTagName    = markerPrefix + ":format"
 	maxLengthTagName = markerPrefix + ":maxLength"
 )
@@ -47,7 +47,7 @@ var (
 func (openAPIDeclarativeValidator) ExtractValidations(t *types.Type, comments []string) (Validations, error) {
 	var result Validations
 	// Leverage the kube-openapi parser for 'k8s:validation:' validations.
-	schema, err := generators.ParseCommentTags(t, comments, markerPrefix)
+	schema, err := generators.ParseCommentTags(t, comments, "+"+markerPrefix)
 	if err != nil {
 		return result, err
 	}
@@ -62,6 +62,29 @@ func (openAPIDeclarativeValidator) ExtractValidations(t *types.Type, comments []
 	}
 
 	return result, nil
+}
+
+func (openAPIDeclarativeValidator) Docs() []TagDoc {
+	return []TagDoc{{
+		Tag:         formatTagName,
+		Description: "Indicates that a string field has a particular format.",
+		Contexts:    []TagContext{TagContextType, TagContextField},
+		Payloads: []TagPayload{{
+			Description: "ip",
+			Docs:        "This field holds an IP address value, either IPv4 or IPv6.",
+		}, {
+			Description: "dns-label",
+			Docs:        "This field holds a DNS label value.",
+		}},
+	}, {
+		Tag:         maxLengthTagName,
+		Description: "Indicates that a string field has a limit on its length.",
+		Contexts:    []TagContext{TagContextType, TagContextField},
+		Payloads: []TagPayload{{
+			Description: "<non-negative integer>",
+			Docs:        "This field must be no more than X characters long.",
+		}},
+	}}
 }
 
 func FormatValidationFunction(format string) FunctionGen {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -82,3 +82,11 @@ func (c *compositeValidator) allow(tagName string) bool {
 
 	return len(c.enabledTags) == 0 || c.enabledTags.Has(tagName)
 }
+
+func (c *compositeValidator) Docs() []TagDoc {
+	var result []TagDoc
+	for _, v := range c.validators {
+		result = append(result, v.Docs()...)
+	}
+	return result
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -47,3 +47,11 @@ func (requiredDeclarativeValidator) ExtractValidations(t *types.Type, comments [
 	}
 	return Validations{Functions: []FunctionGen{Function(requiredTagName, IsFatal|PtrOK, requiredValidator)}}, nil
 }
+
+func (requiredDeclarativeValidator) Docs() []TagDoc {
+	return []TagDoc{{
+		Tag:         requiredTagName,
+		Description: "Indicates that a field is required to be specified.",
+		Contexts:    []TagContext{TagContextType, TagContextField},
+	}}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lithammer/dedent"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/types"
@@ -96,6 +97,50 @@ func (v fixedResultDeclarativeValidator) ExtractValidations(t *types.Type, comme
 	return result, nil
 }
 
+func (v fixedResultDeclarativeValidator) Docs() []TagDoc {
+	if v.result {
+		return []TagDoc{{
+			Tag:         validateTrueTagName,
+			Description: "Always passes validation (useful for testing).",
+			Contexts:    []TagContext{TagContextType, TagContextField},
+			Payloads: []TagPayload{{
+				Description: "<none>",
+				Docs:        "The generated code will have no arguments.",
+			}, {
+				Description: "<quoted-string>",
+				Docs:        "The generated code will include this string.",
+			}, {
+				Description: "<json-object>",
+				Docs: dedent.Dedent(`
+				Schema:
+				  "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
+				  "msg":   <string>          # the generated code will include this string"
+			`),
+			}},
+		}}
+	} else {
+		return []TagDoc{{
+			Tag:         validateFalseTagName,
+			Description: "Always fails validation (useful for testing).",
+			Contexts:    []TagContext{TagContextType, TagContextField},
+			Payloads: []TagPayload{{
+				Description: "<none>",
+				Docs:        "The generated code will have no arguments.",
+			}, {
+				Description: "<quoted-string>",
+				Docs:        "The generated code will include this string.",
+			}, {
+				Description: "<json-object>",
+				Docs: dedent.Dedent(`
+				Schema:
+				  "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
+				  "msg":   <string>          # the generated code will include this string"
+			`),
+			}},
+		}}
+	}
+}
+
 type tagVal struct {
 	flags    FunctionFlags
 	msg      string
@@ -158,4 +203,16 @@ func (v errorDeclarativeValidator) ExtractValidations(t *types.Type, comments []
 		return result, fmt.Errorf("forced error: %q", vals)
 	}
 	return result, nil
+}
+
+func (errorDeclarativeValidator) Docs() []TagDoc {
+	return []TagDoc{{
+		Tag:         validateErrorTagName,
+		Description: "Always fails code generation (useful for testing).",
+		Contexts:    []TagContext{TagContextType, TagContextField},
+		Payloads: []TagPayload{{
+			Description: "<string>",
+			Docs:        "This string will be included in the error message.",
+		}},
+	}}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/lithammer/dedent"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/types"
@@ -103,19 +102,24 @@ func (v fixedResultDeclarativeValidator) Docs() []TagDoc {
 			Tag:         validateTrueTagName,
 			Description: "Always passes validation (useful for testing).",
 			Contexts:    []TagContext{TagContextType, TagContextField},
-			Payloads: []TagPayload{{
+			Payloads: []TagPayloadDoc{{
 				Description: "<none>",
-				Docs:        "The generated code will have no arguments.",
+				Docs:        "",
 			}, {
 				Description: "<quoted-string>",
 				Docs:        "The generated code will include this string.",
 			}, {
 				Description: "<json-object>",
-				Docs: dedent.Dedent(`
-				Schema:
-				  "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
-				  "msg":   <string>          # the generated code will include this string"
-			`),
+				Docs:        "",
+				Schema: []TagPayloadSchema{{
+					Key:   "flags",
+					Value: "<list-of-flag-string>",
+					Docs:  `PtrOK | IsFatal`,
+				}, {
+					Key:   "msg",
+					Value: "<string>",
+					Docs:  "The generated code will include this string.",
+				}},
 			}},
 		}}
 	} else {
@@ -123,19 +127,24 @@ func (v fixedResultDeclarativeValidator) Docs() []TagDoc {
 			Tag:         validateFalseTagName,
 			Description: "Always fails validation (useful for testing).",
 			Contexts:    []TagContext{TagContextType, TagContextField},
-			Payloads: []TagPayload{{
+			Payloads: []TagPayloadDoc{{
 				Description: "<none>",
-				Docs:        "The generated code will have no arguments.",
+				Docs:        "",
 			}, {
 				Description: "<quoted-string>",
 				Docs:        "The generated code will include this string.",
 			}, {
 				Description: "<json-object>",
-				Docs: dedent.Dedent(`
-				Schema:
-				  "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
-				  "msg":   <string>          # the generated code will include this string"
-			`),
+				Docs:        "",
+				Schema: []TagPayloadSchema{{
+					Key:   "flags",
+					Value: "<list-of-flag-string>",
+					Docs:  `PtrOK | IsFatal`,
+				}, {
+					Key:   "msg",
+					Value: "<string>",
+					Docs:  "The generated code will include this string.",
+				}},
 			}},
 		}}
 	}
@@ -210,7 +219,7 @@ func (errorDeclarativeValidator) Docs() []TagDoc {
 		Tag:         validateErrorTagName,
 		Description: "Always fails code generation (useful for testing).",
 		Contexts:    []TagContext{TagContextType, TagContextField},
-		Payloads: []TagPayload{{
+		Payloads: []TagPayloadDoc{{
 			Description: "<string>",
 			Docs:        "This string will be included in the error message.",
 		}},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/lithammer/dedent"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/parser/tags"
@@ -182,4 +183,31 @@ func (c *unionDeclarativeValidator) ExtractValidations(t *types.Type, comments [
 	}
 
 	return result, nil
+}
+
+func (unionDeclarativeValidator) Docs() []TagDoc {
+	return []TagDoc{{
+		Tag:         discriminatorTagName,
+		Description: "Indicates that this field is the discriminator for a union.",
+		Contexts:    []TagContext{TagContextField},
+		Payloads: []TagPayload{{
+			Description: "<json-object>",
+			Docs: dedent.Dedent(`
+                Schema:
+                  "union": <string>  # optional: the name of the union, if more than one exists
+            `),
+		}},
+	}, {
+		Tag:         memberTagName,
+		Description: "Indicates that this field is a member of a union.",
+		Contexts:    []TagContext{TagContextField},
+		Payloads: []TagPayload{{
+			Description: "<json-object>",
+			Docs: dedent.Dedent(`
+                Schema:
+                  "union": <string>       # optional: the name of the union, if more than one exists
+                  "memberName": <string>  # optional: the discriminator value for this member, default is the field name
+            `),
+		}},
+	}}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/lithammer/dedent"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/parser/tags"
@@ -190,24 +189,32 @@ func (unionDeclarativeValidator) Docs() []TagDoc {
 		Tag:         discriminatorTagName,
 		Description: "Indicates that this field is the discriminator for a union.",
 		Contexts:    []TagContext{TagContextField},
-		Payloads: []TagPayload{{
+		Payloads: []TagPayloadDoc{{
 			Description: "<json-object>",
-			Docs: dedent.Dedent(`
-                Schema:
-                  "union": <string>  # optional: the name of the union, if more than one exists
-            `),
+			Docs:        "",
+			Schema: []TagPayloadSchema{{
+				Key:   "union",
+				Value: "<string>",
+				Docs:  "the name of the union, if more than one exists",
+			}},
 		}},
 	}, {
 		Tag:         memberTagName,
 		Description: "Indicates that this field is a member of a union.",
 		Contexts:    []TagContext{TagContextField},
-		Payloads: []TagPayload{{
+		Payloads: []TagPayloadDoc{{
 			Description: "<json-object>",
-			Docs: dedent.Dedent(`
-                Schema:
-                  "union": <string>       # optional: the name of the union, if more than one exists
-                  "memberName": <string>  # optional: the discriminator value for this member, default is the field name
-            `),
+			Docs:        "",
+			Schema: []TagPayloadSchema{{
+				Key:   "union",
+				Value: "<string>",
+				Docs:  "the name of the union, if more than one exists",
+			}, {
+				Key:     "memberName",
+				Value:   "<string>",
+				Docs:    "the discriminator value for this member",
+				Default: "the field's name",
+			}},
 		}},
 	}}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -203,7 +203,7 @@ type TagDoc struct {
 	// Payloads lists zero or more varieties of value for this tag. If this tag
 	// never has a payload, this list should be empty, but if the payload is
 	// optional, this list should include an entry for "<none>".
-	Payloads []TagPayload
+	Payloads []TagPayloadDoc
 }
 
 // TagContext describes where a tag may be attached.
@@ -212,15 +212,24 @@ type TagContext string
 const (
 	// TagContextType indicates that a tag may be attached to a type
 	// definition.
-	TagContextType TagContext = "Type"
+	TagContextType TagContext = "Type definition"
 	// TagContextField indicates that a tag may be attached to a struct
 	// field, the keys of a map, or the values of a map or slice.
-	TagContextField TagContext = "Field"
+	TagContextField TagContext = "Field definition, map key, map/slice value"
 )
 
-// TagPayload describes a value for a tag (e.g `+tagName=tagValue`).  Some
+// TagPayloadDoc describes a value for a tag (e.g `+tagName=tagValue`).  Some
 // tags upport multiple payloads, including <none> (e.g. `+tagName`).
-type TagPayload struct {
+type TagPayloadDoc struct {
 	Description string
-	Docs        string
+	Docs        string             `json:",omitempty"`
+	Schema      []TagPayloadSchema `json:",omitempty"`
+}
+
+// TagPayloadSchema describes a JSON tag payload.
+type TagPayloadSchema struct {
+	Key     string // required
+	Value   string // required
+	Docs    string `json:",omitempty"`
+	Default string `json:",omitempty"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -26,6 +26,10 @@ type DeclarativeValidator interface {
 	// ExtractValidations returns a Validations for the validation this DeclarativeValidator
 	// supports for the given go type, and it's corresponding comment strings.
 	ExtractValidations(t *types.Type, comments []string) (Validations, error)
+
+	// Docs returns user-friendly documentation for all of the tags that this
+	// validator supports.
+	Docs() []TagDoc
 }
 
 // Validations defines the function calls and variables to generate to perform validation.
@@ -185,4 +189,38 @@ func (v variableGen) Var() PrivateVar {
 
 func (v variableGen) Init() FunctionGen {
 	return v.init
+}
+
+// TagDoc describes a comment-tag and its usage.
+type TagDoc struct {
+	// Tag is the tag name, without the leading '+'.
+	Tag string
+	// Description is a short description of this tag's purpose.
+	Description string
+	// Contexts lists the place or places this tag may be used.  Tags used in
+	// the wrong context may or may not cause errors.
+	Contexts []TagContext
+	// Payloads lists zero or more varieties of value for this tag. If this tag
+	// never has a payload, this list should be empty, but if the payload is
+	// optional, this list should include an entry for "<none>".
+	Payloads []TagPayload
+}
+
+// TagContext describes where a tag may be attached.
+type TagContext string
+
+const (
+	// TagContextType indicates that a tag may be attached to a type
+	// definition.
+	TagContextType TagContext = "Type"
+	// TagContextField indicates that a tag may be attached to a struct
+	// field, the keys of a map, or the values of a map or slice.
+	TagContextField TagContext = "Field"
+)
+
+// TagPayload describes a value for a tag (e.g `+tagName=tagValue`).  Some
+// tags upport multiple payloads, including <none> (e.g. `+tagName`).
+type TagPayload struct {
+	Description string
+	Docs        string
 }

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
+	github.com/lithammer/dedent v1.1.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.17.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
-	github.com/lithammer/dedent v1.1.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.17.0
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
```
Tag: +eachKey
Description: Declares a validation for map keys.
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <validation-tag>:  This tag will be evaluated for each key of a map.

Tag: +eachVal
Description: Declares a validation for map and slice values.
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <validation-tag>:  This tag will be evaluated for each value of a map or slice.

Tag: +enum
Description: Indicates that a string type is an enum. All const values of this type are considered values in the enum.
Attach to:
    - type definitions
Tag value(s):

Tag: +k8s:validation::format
Description: Indicates that a string field has a particular format.
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    ip:  This field holds an IP address value, either IPv4 or IPv6.
    dns-label:  This field holds a DNS label value.

Tag: +k8s:validation::maxLength
Description: Indicates that a string field has a limit on its length.
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <non-negative integer>:  This field must be no more than X characters long.

Tag: +required
Description: Indicates that a field is required to be specified.
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):

Tag: +validateError
Description: Always fails code generation (useful for testing).
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <string>:  This string will be included in the error message.

Tag: +validateFalse
Description: Always fails validation (useful for testing).
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <none>:  The generated code will have no arguments.
    <quoted-string>:  The generated code will include this string.
    <json-object>:  Schema:
        "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
        "msg":   <string>          # The generated code will include this string"

Tag: +validateFalse
Description: Always fails validation (useful for testing).
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <none>:  The generated code will have no arguments.
    <quoted-string>:  The generated code will include this string.
    <json-object>:  Schema:
        "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
        "msg":   <string>          # The generated code will include this string"

Tag: +validateTrue
Description: Always passes validation (useful for testing).
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <none>:  The generated code will have no arguments.
    <quoted-string>:  The generated code will include this string.
    <json-object>:  Schema:
        "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
        "msg":   <string>          # The generated code will include this string"

Tag: +validateTrue
Description: Always passes validation (useful for testing).
Attach to:
    - type definitions
    - field definitions (including map keys and map/slice values)
Tag value(s):
    <none>:  The generated code will have no arguments.
    <quoted-string>:  The generated code will include this string.
    <json-object>:  Schema:
        "flags": <list-of-string>  # optional: "PtrOK" or "IsFatal"
        "msg":   <string>          # The generated code will include this string"

```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
