### PR TITLE
Add a "test scheme" to use with output_test

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/doc.go
@@ -16,9 +16,14 @@ limitations under the License.
 
 // Note: this selects all types in the package.
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package trivial
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct{}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/trivial/zz_generated.validations.go
@@ -26,15 +26,15 @@ import (
 
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*E1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_E1(opCtx, obj.(*E1), safe.Cast[E1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/doc.go
@@ -16,9 +16,14 @@ limitations under the License.
 
 // Note: this selects all types in the package.
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package withfieldvalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	// +validateTrue="field T1.S"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/doc.go
@@ -16,20 +16,25 @@ limitations under the License.
 
 // Note: this selects all types in the package.
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package withtypevalidations
 
-// +validateTrue="type T1"
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
+// +validateFalse="type T1"
 type T1 struct {
-	// +validateTrue="field T1.S"
+	// +validateFalse="field T1.S"
 	S string `json:"s"`
 }
 
 // Note: this has no validations.
 type T2 struct{}
 
-// +validateTrue="type E1"
+// +validateFalse="type E1"
 type E1 string
 
 // Note: this has no validations.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/docs_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/docs_test.go
@@ -1,0 +1,53 @@
+package withtypevalidations
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	pointer "k8s.io/utils/ptr"
+)
+
+// TODO: Replace this with a more convenient test utility. This is just a temporary sanity check.
+func Test(t *testing.T) {
+	expectValid := []any{
+		&T2{},
+		pointer.To(E2("x")),
+	}
+
+	expectInvalid := []struct {
+		in   any
+		want sets.Set[string]
+	}{
+		{
+			in:   &T1{S: "x"},
+			want: sets.New("forced failure: type T1", "forced failure: field T1.S"),
+		},
+		{
+			in:   pointer.To(E1("x")),
+			want: sets.New("forced failure: type E1"),
+		},
+	}
+
+	for _, v := range expectValid {
+		if len(localSchemeBuilder.Validate(v)) > 0 {
+			t.Errorf("expected no validation errors")
+		}
+		if len(localSchemeBuilder.ValidateUpdate(v, v)) > 0 {
+			t.Errorf("expected no validation errors")
+		}
+	}
+
+	for _, v := range expectInvalid {
+		t.Run(fmt.Sprintf("%#+v", v.in), func(t *testing.T) {
+			got := localSchemeBuilder.Validate(v.in)
+			gotMsgs := sets.New[string]()
+			for _, g := range got {
+				gotMsgs.Insert(g.Detail)
+			}
+			if !v.want.Equal(gotMsgs) {
+				t.Errorf("want validation %v but got %v", v.want, gotMsgs)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*E1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_E1(opCtx, obj.(*E1), safe.Cast[E1](oldObj), nil)
@@ -66,7 +66,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 func Validate_E1(opCtx operation.Context, obj, oldObj *E1, fldPath *field.Path) (errs field.ErrorList) {
 	// type E1
 	if obj != nil {
-		errs = append(errs, validate.FixedResult(fldPath, *obj, true, "type E1")...)
+		errs = append(errs, validate.FixedResult(fldPath, *obj, false, "type E1")...)
 	}
 
 	return errs
@@ -79,13 +79,13 @@ func Validate_E2(opCtx operation.Context, obj, oldObj *E2, fldPath *field.Path) 
 func Validate_T1(opCtx operation.Context, obj, oldObj *T1, fldPath *field.Path) (errs field.ErrorList) {
 	// type T1
 	if obj != nil {
-		errs = append(errs, validate.FixedResult(fldPath, *obj, true, "type T1")...)
+		errs = append(errs, validate.FixedResult(fldPath, *obj, false, "type T1")...)
 	}
 
 	// field T1.S
 	errs = append(errs,
 		func(obj string, oldObj *string, fldPath *field.Path) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(fldPath, obj, true, "field T1.S")...)
+			errs = append(errs, validate.FixedResult(fldPath, obj, false, "field T1.S")...)
 			return
 		}(obj.S, safe.Field(oldObj, func(oldObj T1) *string { return &oldObj.S }), fldPath.Child("s"))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
@@ -15,11 +15,17 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package crosspkg
 
-import "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+import (
+	"k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+	"k8s.io/code-generator/cmd/validation-gen/testscheme"
+)
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta     int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
@@ -26,16 +26,16 @@ import (
 
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
 	primitives "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package elidenovalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/enums/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/enums/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package enums
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/enums/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/enums/zz_generated.validations.go
@@ -27,16 +27,16 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/enum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/enum/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package enum
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type E1"
 type E1 string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/enum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/enum/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/key_only/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/key_only/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package keyonly
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/key_only/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/key_only/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package multiplevalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_pointer/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_pointer/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package pointerpointer
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_pointer/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_pointer/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_primitive/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package pointerprimitive
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/pointer_primitive/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_map/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_map/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitivemap
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_map/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_pointer/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_pointer/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitivepointer
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_pointer/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_pointer/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_primitive/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitiveprimitive
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_primitive/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_struct/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitivestruct
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_struct/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_typedef/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package typedef
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_typedef/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/primitive_typedef/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/struct_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/struct_primitive/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package structprimitive
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/struct_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/struct_primitive/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package typedef
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/val_only/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/val_only/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitiveprimitive
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/val_only/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/val_only/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package multipletags
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1 #1"
 // +validateTrue="type T1 #2"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_generation/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_generation/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package nogeneration
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +validateTrue="from field T1.S"
 	S string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/doc.go
@@ -16,9 +16,14 @@ limitations under the License.
 
 // Note: no types match this.
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package notypesmatch
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	// +validateTrue="from field T1.S"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/no_types_match/zz_generated.validations.go
@@ -22,13 +22,13 @@ limitations under the License.
 package notypesmatch
 
 import (
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package trivial
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/trivial/zz_generated.validations.go
@@ -26,15 +26,15 @@ import (
 
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package withfieldvalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package withtypevalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package structs
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type Tother struct {
 	// +validateTrue={"flags":[], "msg":"Tother, no flags"}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T00)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T00(opCtx, obj.(*T00), safe.Cast[T00](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package typedefs
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Treat these as 4 bits, and ensure all combinations
 //   bit 0: no flags

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*E00)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_E00(opCtx, obj.(*E00), safe.Cast[E00](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package pointers
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitives
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	TypeMeta int

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package publicprivate
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 type T1 struct {
 	// +validateTrue="field T1.Public"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=*
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package recursvie
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*E1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_E1(opCtx, obj.(*E1), safe.Cast[E1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/enum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/enum/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package enum
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type E1"
 type E1 string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/enum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/enum/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package multiplevalidations
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/pointer/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/pointer/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package pointer
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/pointer/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/pointer/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/primitive/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package primitive
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/primitive/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package slice
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/structs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/structs/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package structs
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/structs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/structs/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package typedef
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type T1"
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/doc.go
@@ -15,11 +15,17 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package type_args
 
-import "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+import (
+	"k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+	"k8s.io/code-generator/cmd/validation-gen/testscheme"
+)
+
+var localSchemeBuilder = testscheme.New()
 
 // Empty discriminated union
 type T1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
@@ -27,16 +27,16 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
 	primitives "k8s.io/code-generator/cmd/validation-gen/output_tests/primitives"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package typedefs
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // +validateTrue="type E1"
 type E1 string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package discriminated_union
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Discriminated union
 type DU struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*DU)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_DU(opCtx, obj.(*DU), safe.Cast[DU](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_custom_members/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_custom_members/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package discriminated_union_custom_members
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Discriminated union with custom member names
 type DU struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_custom_members/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*DU)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_DU(opCtx, obj.(*DU), safe.Cast[DU](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_empty/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_empty/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package discriminated_union_empty
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Empty discriminated union
 type DU1 struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/discriminated_union_empty/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*DU1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_DU1(opCtx, obj.(*DU1), safe.Cast[DU1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_discriminated_unions/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_discriminated_unions/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package multiple_discriminated_unions
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Two discriminated unions in the same struct
 type DU struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_discriminated_unions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_discriminated_unions/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*DU)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_DU(opCtx, obj.(*DU), safe.Cast[DU](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_unions/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_unions/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package multiple_unions
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Two non-discriminated unions in the same struct
 type U struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_unions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/multiple_unions/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*U)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_U(opCtx, obj.(*U), safe.Cast[U](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package union
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Non-discriminated union
 type U struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*U)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_U(opCtx, obj.(*U), safe.Cast[U](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union_custom_members/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union_custom_members/doc.go
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 // +k8s:validation-gen=TypeMeta
+// +k8s:validation-gen-scheme-registry=k8s.io/code-generator/cmd/validation-gen/testscheme.Scheme
 
 // This is a test package.
 package union_custom_members
+
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
 
 // Non-discriminated union with custom member names
 type U struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union_custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/unions/union_custom_members/zz_generated.validations.go
@@ -27,15 +27,15 @@ import (
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
 	validate "k8s.io/apimachinery/pkg/api/validate"
-	runtime "k8s.io/apimachinery/pkg/runtime"
 	field "k8s.io/apimachinery/pkg/util/validation/field"
+	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
 func init() { localSchemeBuilder.Register(RegisterValidations) }
 
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
-func RegisterValidations(scheme *runtime.Scheme) error {
+func RegisterValidations(scheme *testscheme.Scheme) error {
 	scheme.AddValidationFunc((*T1)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
 			return Validate_T1(opCtx, obj.(*T1), safe.Cast[T1](oldObj), nil)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/listmap_multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/listmap_multiple_keys/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package listmap_multiple_keys
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +listType=map
 	// +listMapKey=k1

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/listmap_single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/listmap_single_key/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package listmap_single_key
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +listType=map
 	// +listMapKey=k1

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package lists
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	M1 []LM1 `json:"lm1"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package maps
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	M1 map[string]M1 `json:"m1"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package primitive_pointers
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +validateTrue={"flags":["UpdateOnly"], "msg":"T1.SP, UpdateOnly"}
 	SP *string `json:"sp"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers_ptr_ok/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers_ptr_ok/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package primitive_pointers_ptr_ok
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +validateTrue={"flags":["UpdateOnly", "PtrOK"], "msg":"T1.SP, UpdateOnly, PtrOK"}
 	SP *string `json:"sp"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package primitives
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +validateTrue={"flags":["UpdateOnly"], "msg":"T1.US, UpdateOnly"}
 	US string `json:"us"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives_ptr_ok/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives_ptr_ok/doc.go
@@ -19,6 +19,10 @@ limitations under the License.
 // This is a test package.
 package primitives_ptr_ok
 
+import "k8s.io/code-generator/cmd/validation-gen/testscheme"
+
+var localSchemeBuilder = testscheme.New()
+
 type T1 struct {
 	// +validateTrue={"flags":["UpdateOnly", "PtrOK"], "msg":"T1.US, UpdateOnly, PtrOK"}
 	US string `json:"us"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testscheme
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Scheme is similar to runtime.Scheme, but for validation testing purposes. Scheme only supports validation,
+// supports registration of any type (not just runtime.Object) and implements Register directly, allowing it
+// to also be used as a scheme builder.
+// Must only be used with tests that perform all registration before calls to validate.
+type Scheme struct {
+	validationFuncs    map[reflect.Type]func(opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList
+	registrationErrors field.ErrorList
+}
+
+// New creates a new Scheme.
+func New() *Scheme {
+	return &Scheme{validationFuncs: map[reflect.Type]func(opCtx operation.Context, object interface{}, oldObject interface{}, subresources ...string) field.ErrorList{}}
+}
+
+// AddValidationFunc registers a validation function.
+// Last writer wins.
+func (s *Scheme) AddValidationFunc(srcType any, fn func(opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList) {
+	s.validationFuncs[reflect.TypeOf(srcType)] = fn
+}
+
+// Validate validates an object using the registered validation function.
+func (s *Scheme) Validate(object any, subresources ...string) field.ErrorList {
+	if len(s.registrationErrors) > 0 {
+		return s.registrationErrors // short circuit with registration errors if any are present
+	}
+	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
+		return fn(operation.Context{Operation: operation.Create}, object, nil, subresources...)
+	}
+	return nil
+}
+
+// ValidateUpdate validates an update to an object using the registered validation function.
+func (s *Scheme) ValidateUpdate(object, oldObject any, subresources ...string) field.ErrorList {
+	if len(s.registrationErrors) > 0 {
+		return s.registrationErrors // short circuit with registration errors if any are present
+	}
+	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
+		return fn(operation.Context{Operation: operation.Update}, oldObject, object, subresources...)
+	}
+	return nil
+}
+
+// Register adds a scheme setup function to the list.
+func (s *Scheme) Register(funcs ...func(*Scheme) error) {
+	for _, f := range funcs {
+		err := f(s)
+		if err != nil {
+			s.registrationErrors = append(s.registrationErrors, toRegistrationError(err))
+		}
+	}
+}
+
+func toRegistrationError(err error) *field.Error {
+	return field.InternalError(nil, fmt.Errorf("registration error: %w", err))
+}


### PR DESCRIPTION
Stacking this on validation-gen-updates until that merges.

All scheme registration should compile with this.  I added one test demonstrating that validations both pass and fail as expected. We can expand on that once we agree on an approach for this PR.