### PR TITLE
Fix a bug with recursive types

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/doc.go
@@ -55,3 +55,9 @@ type E1 []E1
 // +validateFalse="type E2"
 // +eachVal=+validateFalse="type E2 values"
 type E2 []*E2
+
+// NOTE: no validations.
+type T3 struct {
+	// NOTE: no validations.
+	PT3 *T3 `json:"pt3"`
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
@@ -60,6 +60,12 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
+	scheme.AddValidationFunc((*T3)(nil), func(opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+		if len(subresources) == 0 {
+			return Validate_T3(opCtx, obj.(*T3), safe.Cast[*T3](oldObj), nil)
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
+	})
 	return nil
 }
 
@@ -156,5 +162,10 @@ func Validate_T2(opCtx operation.Context, obj, oldObj *T2, fldPath *field.Path) 
 			return
 		}(obj.PT2, safe.Field(oldObj, func(oldObj *T2) *T2 { return oldObj.PT2 }), fldPath.Child("pt2"))...)
 
+	return errs
+}
+
+func Validate_T3(opCtx operation.Context, obj, oldObj *T3, fldPath *field.Path) (errs field.ErrorList) {
+	// field T3.PT3 has no validation
 	return errs
 }


### PR DESCRIPTION
If there is no validation on a recursive type, the generator will recurse until it stack-overflows.  Now we track seen types and terminate recursion.