### PR TITLE
Unbreak IsValidIP() for core validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"unicode"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/validate"
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -336,8 +337,9 @@ func IsValidPortName(port string) []string {
 }
 
 // IsValidIP tests that the argument is a valid IP address.
-// Deprecated: Use k8s.io/apimachinery/pkg/api/validate.IP instead.
-var IsValidIP = validate.IP
+func IsValidIP(fldPath *field.Path, value string) field.ErrorList {
+	return validate.IP(operation.Context{}, fldPath, &value, nil)
+}
 
 // IsValidIPv4Address tests that the argument is a valid IPv4 address.
 func IsValidIPv4Address(fldPath *field.Path, value string) field.ErrorList {


### PR DESCRIPTION
When we did this, the signatures were compatible, but then they drifted.