### PR TITLE
Parse maxItems,maxLength and format independently

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -8323,7 +8323,6 @@ func Validate_Volume(opCtx operation.Context, obj, oldObj *corev1.Volume, fldPat
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.DNSLabel(opCtx, fldPath, obj, oldObj)...)
 			return
 		}(&obj.Name, safe.Field(oldObj, func(oldObj *corev1.Volume) *string { return &oldObj.Name }), fldPath.Child("name"))...)
 


### PR DESCRIPTION
We don't really benefit from using the OpenAPI extractor.  We don't agree with how it represents enums, and I don't agree with how it handles format either, so let's just parse what we need.  We need to have utilities to do that in general anyway.