### PR TITLE
Drop validation-gen-enabled-tags and validation-gen-disabled-tags

### DIFF
--- a/TODO.validation-gen
+++ b/TODO.validation-gen
@@ -24,9 +24,6 @@ P0:
 - Fix subresources
   - "spec" and "status" are hard coded in generator, drive them off of a `+subresource=status` tag?
   - Do we need to do anything special for "scale"?
-- Do we really need enabled-tags and disabled-tags logic?  If so, document.
-  - rename "disabled-tags" to "disabled-tag" and document as repeated
-
 
 P1:
 - Consider adding flag-optional mutation checks along the way through the REST

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
@@ -36,8 +36,6 @@ import (
 const (
 	tagName               = "k8s:validation-gen"
 	inputTagName          = "k8s:validation-gen-input"
-	enabledTagName        = "k8s:validation-gen-enabled-tags"
-	disabledTagName       = "k8s:validation-gen-disabled-tags"
 	schemeRegistryTagName = "k8s:validation-gen-scheme-registry" // defaults to k8s.io/apimachinery/pkg.runtime.Scheme
 	testFixtureTagName    = "k8s:validation-gen-test-fixture"    // if set, generate go test files for test fixtures.  Supported values: "validateFalse".
 )
@@ -55,11 +53,6 @@ func extractTag(comments []string) ([]string, bool) {
 
 func extractInputTag(comments []string) []string {
 	return gengo.ExtractCommentTags("+", comments)[inputTagName]
-}
-
-func extractFiltersTags(comments []string) (enabled, disabled []string) {
-	return gengo.ExtractCommentTags("+", comments)[enabledTagName],
-		gengo.ExtractCommentTags("+", comments)[disabledTagName]
 }
 
 func checkTag(comments []string, require ...string) bool {
@@ -202,8 +195,7 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 
 		pkg := context.Universe[input]
 
-		enabledTags, disabledTags := extractFiltersTags(pkg.Comments)
-		declarativeValidator := validators.NewValidator(context, enabledTags, disabledTags)
+		declarativeValidator := validators.NewValidator(context)
 		schemaRegistry := schemeRegistryTag(pkg)
 
 		typesWith, found := extractTag(pkg.Comments)


### PR DESCRIPTION
Since we're using `k8s:` prefixes to selectively enabled declarative validation, we don't need these options.  Removing them simplifies things.