### PR TITLE
feat: Add linting functionality to validation-gen with --lint-only flag

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/gengo/v2/types"
+	"k8s.io/klog/v2"
+)
+
+// linter is a struct that holds the state of the linting process.
+// It contains a map of types that have been linted, a list of linting rules,
+// and a list of errors that occurred during the linting process.
+type linter struct {
+	linted map[*types.Type]bool
+	rules  []lintRule
+	// lintErrors is a list of errors that occurred during the linting process.
+	// lintErrors would be in the format:
+	// field <field_name>: <lint broken message>
+	// type <type_name>: <lint broken message>
+	lintErrors []error
+}
+
+var defaultRules = []lintRule{
+	ruleOptionalAndRequired,
+	ruleRequiredAndDefault,
+}
+
+func (l *linter) AddError(field, msg string) {
+	l.lintErrors = append(l.lintErrors, fmt.Errorf("%s: %s", field, msg))
+}
+
+func newLinter(rules ...lintRule) *linter {
+	if len(rules) == 0 {
+		rules = defaultRules
+	}
+	return &linter{
+		linted:     make(map[*types.Type]bool),
+		rules:      rules,
+		lintErrors: []error{},
+	}
+}
+
+func (l *linter) lintType(t *types.Type) error {
+	if _, ok := l.linted[t]; ok {
+		return nil
+	}
+	l.linted[t] = true
+
+	if t.CommentLines != nil {
+		klog.V(5).Infof("linting type %s", t.Name.String())
+		lintErrs, err := l.lintComments(t.CommentLines)
+		if err != nil {
+			return err
+		}
+		for _, lintErr := range lintErrs {
+			l.AddError("type "+t.Name.String(), lintErr)
+		}
+	}
+	switch t.Kind {
+	case types.Alias:
+		// Recursively lint the underlying type of the alias.
+		if err := l.lintType(t.Underlying); err != nil {
+			return err
+		}
+	case types.Struct:
+		// Recursively lint each member of the struct.
+		for _, member := range t.Members {
+			klog.V(5).Infof("linting comments for field %s of type %s", member.String(), t.Name.String())
+			lintErrs, err := l.lintComments(member.CommentLines)
+			if err != nil {
+				return err
+			}
+			for _, lintErr := range lintErrs {
+				l.AddError("type "+t.Name.String(), lintErr)
+			}
+			l.lintType(member.Type)
+		}
+	case types.Slice, types.Array, types.Pointer:
+		// Recursively lint the element type of the slice or array.
+		if err := l.lintType(t.Elem); err != nil {
+			return err
+		}
+	case types.Map:
+		// Recursively lint the key and element types of the map.
+		if err := l.lintType(t.Key); err != nil {
+			return err
+		}
+		if err := l.lintType(t.Elem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// lintRule is a function that validates a slice of comments.
+// It returns a string as an error message if the comments are invalid,
+// and an error there is an error happened during the linting process.
+type lintRule func(comments []string) (string, error)
+
+// lintComments runs all registered rules on a slice of comments.
+func (l *linter) lintComments(comments []string) ([]string, error) {
+	var lintErrs []string
+	for _, rule := range l.rules {
+		if msg, err := rule(comments); err != nil {
+			return nil, err
+		} else if msg != "" {
+			lintErrs = append(lintErrs, msg)
+		}
+	}
+
+	return lintErrs, nil
+}
+
+// conflictingTagsRule checks for conflicting tags in a slice of comments.
+func conflictingTagsRule(comments []string, tags ...string) (string, error) {
+	if len(tags) < 2 {
+		return "", fmt.Errorf("at least two tags must be provided")
+	}
+	tagCount := make(map[string]bool)
+	for _, comment := range comments {
+		for _, tag := range tags {
+			if strings.HasPrefix(comment, tag) {
+				tagCount[tag] = true
+			}
+		}
+	}
+	if len(tagCount) > 1 {
+		return fmt.Sprintf("conflicting tags: {%s}", strings.Join(tags, ", ")), nil
+	}
+	return "", nil
+}
+
+// ruleOptionalAndRequired checks for conflicting tags +k8s:optional and +k8s:required in a slice of comments.
+func ruleOptionalAndRequired(comments []string) (string, error) {
+	return conflictingTagsRule(comments, "+k8s:optional", "+k8s:required")
+}
+
+// ruleRequiredAndDefault checks for conflicting tags +k8s:required and +k8s:default in a slice of comments.
+func ruleRequiredAndDefault(comments []string) (string, error) {
+	return conflictingTagsRule(comments, "+k8s:required", "+k8s:default")
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/gengo/v2/types"
+)
+
+func ruleAlwaysPass(comments []string) (string, error) {
+	return "", nil
+}
+
+func ruleAlwaysFail(comments []string) (string, error) {
+	return "lintfail", nil
+}
+
+func ruleAlwaysErr(comments []string) (string, error) {
+	return "", errors.New("linterr")
+}
+
+func mkCountRule(counter *int, realRule lintRule) lintRule {
+	return func(comments []string) (string, error) {
+		(*counter)++
+		return realRule(comments)
+	}
+}
+
+func TestLintCommentsRuleInvocation(t *testing.T) {
+	tests := []struct {
+		name              string
+		rules             []lintRule
+		commentLineGroups [][]string
+		wantErr           bool
+		wantCount         int
+	}{
+		{
+			name:              "0 rules, 0 comments",
+			rules:             []lintRule{},
+			commentLineGroups: [][]string{},
+			wantErr:           false,
+			wantCount:         0,
+		},
+		{
+			name:              "1 rule, 1 comment",
+			rules:             []lintRule{ruleAlwaysPass},
+			commentLineGroups: [][]string{{"comment"}},
+			wantErr:           false,
+			wantCount:         1,
+		},
+		{
+			name:              "3 rules, 3 comments",
+			rules:             []lintRule{ruleAlwaysPass, ruleAlwaysFail, ruleAlwaysErr},
+			commentLineGroups: [][]string{{"comment1"}, {"comment2"}, {"comment3"}},
+			wantErr:           true,
+			wantCount:         9,
+		},
+		{
+			name:              "1 rule, 1 comment, rule fails",
+			rules:             []lintRule{ruleAlwaysFail},
+			commentLineGroups: [][]string{{"comment"}},
+			wantErr:           false,
+			wantCount:         1,
+		},
+		{
+			name:              "1 rule, 1 comment, rule errors",
+			rules:             []lintRule{ruleAlwaysErr},
+			commentLineGroups: [][]string{{"comment"}},
+			wantErr:           true,
+			wantCount:         1,
+		},
+		{
+			name:              "3 rules, 1 comment, rule errors in the middle",
+			rules:             []lintRule{ruleAlwaysPass, ruleAlwaysErr, ruleAlwaysFail},
+			commentLineGroups: [][]string{{"comment"}},
+			wantErr:           true,
+			wantCount:         2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := 0
+			rules := make([]lintRule, len(tt.rules))
+			for i, rule := range tt.rules {
+				rules[i] = mkCountRule(&counter, rule)
+			}
+			l := newLinter(rules...)
+			for _, commentLines := range tt.commentLineGroups {
+				_, err := l.lintComments(commentLines)
+				gotErr := err != nil
+				if gotErr != tt.wantErr {
+					t.Errorf("lintComments() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if counter != tt.wantCount {
+				t.Errorf("expected %d rule invocations, got %d", tt.wantCount, counter)
+			}
+		})
+	}
+}
+
+func TestRuleOptionalAndRequired(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []string
+		wantMsg  string
+		wantErr  bool
+	}{
+		{
+			name:     "no comments",
+			comments: []string{},
+			wantMsg:  "",
+		},
+		{
+			name:     "only optional",
+			comments: []string{"+k8s:optional"},
+			wantMsg:  "",
+		},
+		{
+			name:     "only required",
+			comments: []string{"+k8s:required"},
+			wantMsg:  "",
+		},
+		{
+			name:     "optional and required",
+			comments: []string{"+k8s:optional", "+k8s:required"},
+			wantMsg:  "conflicting tags: {+k8s:optional, +k8s:required}",
+		},
+		{
+			name:     "optional, empty, required",
+			comments: []string{"+k8s:optional", "", "+k8s:required"},
+			wantMsg:  "conflicting tags: {+k8s:optional, +k8s:required}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, _ := ruleOptionalAndRequired(tt.comments)
+			if msg != tt.wantMsg {
+				t.Errorf("ruleOptionalAndRequired() msg = %v, wantMsg %v", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestRuleRequiredAndDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []string
+		wantMsg  string
+	}{
+		{
+			name:     "no comments",
+			comments: []string{},
+			wantMsg:  "",
+		},
+		{
+			name:     "only required",
+			comments: []string{"+k8s:required"},
+			wantMsg:  "",
+		},
+		{
+			name:     "only default",
+			comments: []string{"+k8s:default=somevalue"},
+			wantMsg:  "",
+		},
+		{
+			name:     "required and default",
+			comments: []string{"+k8s:required", "+k8s:default=somevalue"},
+			wantMsg:  "conflicting tags: {+k8s:required, +k8s:default}",
+		},
+		{
+			name:     "required, empty, default",
+			comments: []string{"+k8s:required", "", "+k8s:default=somevalue"},
+			wantMsg:  "conflicting tags: {+k8s:required, +k8s:default}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, _ := ruleRequiredAndDefault(tt.comments)
+			if msg != tt.wantMsg {
+				t.Errorf("ruleRequiredAndDefault() msg = %v, wantMsg %v", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestConflictingTagsRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []string
+		tags     []string
+		wantMsg  string
+		wantErr  bool
+	}{
+		{
+			name:     "no comments",
+			comments: []string{},
+			tags:     []string{"+tag1", "+tag2"},
+			wantMsg:  "",
+		},
+		{
+			name:     "only tag1",
+			comments: []string{"+tag1"},
+			tags:     []string{"+tag1", "+tag2"},
+			wantMsg:  "",
+		},
+		{
+			name:     "tag1, empty, tag2",
+			comments: []string{"+tag1", "", "+tag2"},
+			tags:     []string{"+tag1", "+tag2"},
+			wantMsg:  "conflicting tags: {+tag1, +tag2}",
+		},
+		{
+			name:     "3 tags",
+			comments: []string{"tag1", "+tag2", "+tag3=value"},
+			tags:     []string{"+tag1", "+tag2", "+tag3"},
+			wantMsg:  "conflicting tags: {+tag1, +tag2, +tag3}",
+		},
+		{
+			name:     "less than 2 tags",
+			comments: []string{"+tag1"},
+			tags:     []string{"+tag1"},
+			wantMsg:  "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := conflictingTagsRule(tt.comments, tt.tags...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("conflictingTagsRule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if msg != tt.wantMsg {
+				t.Errorf("conflictingTagsRule() msg = %v, wantMsg %v", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestLintType(t *testing.T) {
+	tests := []struct {
+		name        string
+		typeToLint  *types.Type
+		wantCount   int
+		expectError bool
+	}{
+		{
+			name: "No comments",
+			typeToLint: &types.Type{
+				Name:         types.Name{Package: "testpkg", Name: "TestType"},
+				CommentLines: nil,
+			},
+			wantCount:   0,
+			expectError: false,
+		},
+		{
+			name: "Valid comments",
+			typeToLint: &types.Type{
+				Name:         types.Name{Package: "testpkg", Name: "TestType"},
+				CommentLines: []string{"+k8s:optional"},
+			},
+			wantCount:   1,
+			expectError: false,
+		},
+		{
+			name: "Pointer type",
+			typeToLint: &types.Type{
+				Name:         types.Name{Package: "testpkg", Name: "TestPointer"},
+				Kind:         types.Pointer,
+				Elem:         &types.Type{Name: types.Name{Package: "testpkg", Name: "ElemType"}, CommentLines: []string{"+k8s:optional"}},
+				CommentLines: []string{"+k8s:optional"},
+			},
+			wantCount:   2,
+			expectError: false,
+		},
+		{
+			name: "Slice of pointers",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "testpkg", Name: "TestSlice"},
+				Kind: types.Slice,
+				Elem: &types.Type{
+					Name:         types.Name{Package: "testpkg", Name: "PointerElem"},
+					Kind:         types.Pointer,
+					Elem:         &types.Type{Name: types.Name{Package: "testpkg", Name: "ElemType"}, CommentLines: []string{"+k8s:optional"}},
+					CommentLines: []string{"+k8s:optional"},
+				},
+				CommentLines: []string{"+k8s:optional"},
+			},
+			wantCount:   3,
+			expectError: false,
+		},
+		{
+			name: "Map to pointers",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "testpkg", Name: "TestMap"},
+				Kind: types.Map,
+				Key:  &types.Type{Name: types.Name{Package: "testpkg", Name: "KeyType"}, CommentLines: []string{"+k8s:required"}},
+				Elem: &types.Type{
+					Name:         types.Name{Package: "testpkg", Name: "PointerElem"},
+					Kind:         types.Pointer,
+					Elem:         &types.Type{Name: types.Name{Package: "testpkg", Name: "ElemType"}, CommentLines: []string{"+k8s:optional"}},
+					CommentLines: []string{"+k8s:optional"},
+				},
+				CommentLines: []string{"+k8s:optional"},
+			},
+			wantCount:   4,
+			expectError: false,
+		},
+		{
+			name: "Alias to pointers",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "testpkg", Name: "TestAlias"},
+				Kind: types.Alias,
+				Underlying: &types.Type{
+					Name:         types.Name{Package: "testpkg", Name: "PointerElem"},
+					Kind:         types.Pointer,
+					Elem:         &types.Type{Name: types.Name{Package: "testpkg", Name: "ElemType"}, CommentLines: []string{"+k8s:optional"}},
+					CommentLines: []string{"+k8s:optional"},
+				},
+				CommentLines: []string{"+k8s:optional"},
+			},
+			wantCount:   3,
+			expectError: false,
+		},
+		{
+			name: "Struct with members",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "testpkg", Name: "TestStruct"},
+				Kind: types.Struct,
+				Members: []types.Member{
+					{
+						Name:         "Field1",
+						Type:         &types.Type{Name: types.Name{Package: "testpkg", Name: "FieldType"}},
+						CommentLines: []string{"+k8s:optional"},
+					},
+					{
+						Name:         "Field2",
+						Type:         &types.Type{Name: types.Name{Package: "testpkg", Name: "FieldType"}},
+						CommentLines: []string{"+k8s:required"},
+					},
+				},
+			},
+			wantCount:   2,
+			expectError: false,
+		},
+		{
+			name: "Nested types",
+			typeToLint: &types.Type{
+				Name: types.Name{Package: "testpkg", Name: "TestStruct"},
+				Kind: types.Struct,
+				Members: []types.Member{
+					{
+						Name: "Field1",
+						Type: &types.Type{
+							Name:         types.Name{Package: "testpkg", Name: "NestedStruct"},
+							Kind:         types.Struct,
+							CommentLines: []string{"+k8s:optional"},
+							Members: []types.Member{
+								{
+									Name:         "NestedField1",
+									Type:         &types.Type{Name: types.Name{Package: "testpkg", Name: "NestedFieldType"}},
+									CommentLines: []string{"+k8s:required"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCount:   3,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := 0
+			rules := []lintRule{mkCountRule(&counter, ruleAlwaysPass)}
+			l := newLinter(rules...)
+			l.lintType(tt.typeToLint)
+			gotErr := len(l.lintErrors) > 0
+			if gotErr != tt.expectError {
+				t.Errorf("LintType() errors = %v, expectError %v", l.lintErrors, tt.expectError)
+			}
+			if counter != tt.wantCount {
+				t.Errorf("expected %d rule invocations, got %d", tt.wantCount, counter)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -76,6 +76,7 @@ type Args struct {
 	ExtraPkgs    []string // Always consider these as last-ditch possibilities for validations.
 	GoHeaderFile string
 	PrintDocs    bool
+	Lint         bool
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -88,6 +89,8 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.BoolVar(&args.PrintDocs, "docs", false,
 		"print documentation for supported declarative validations, and then exit")
+	fs.BoolVar(&args.Lint, "lint", false,
+		"only run linting checks, do not generate code")
 }
 
 // Validate checks the given arguments.
@@ -108,7 +111,7 @@ func printDocs() {
 	}
 
 	// This gets a composite validator which aggregates the many plugins.
-	validator := validators.NewValidator(c, nil, nil)
+	validator := validators.NewValidator(c)
 
 	docs := builtinTagDocs()
 	docs = append(docs, validator.Docs()...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Run lint on the comment tags

When flag `--lint-only` tag is added, the validation-gen command would run lint on the targeted packages comment tags and print out the lint errors without executing the code generation.