### PR TITLE
Rename "operation.Context"

### DIFF
--- a/TODO.validation-gen
+++ b/TODO.validation-gen
@@ -79,7 +79,6 @@ P2:
 - Linear or bin-search ListMap rather thsan build a map?
 - enums: pass the sorted list of value rather than a set, do a linear/binary search
 - Revisit whether eachKey/eachVal can be a single function call
-- Think of a better name and home for operation.Context
 - Add a way to store a comment with a FunctionGen, so we could emit things like
   the which tag caused it
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/operation/operation.go
@@ -18,15 +18,21 @@ package operation
 
 import "k8s.io/apimachinery/pkg/util/sets"
 
-// Context provides contextual information about a validation request and the API
+// Operation provides contextual information about a validation request and the API
 // operation being validated.
 // This type is intended for use with generate validation code and may be enhanced
 // in the future to include other information needed to validate requests.
-type Context struct {
-	Operation Operation
+type Operation struct {
+	// Type is the category of operation being validated.  This does not
+	// differentiate between HTTP verbs like PUT and PATCH, but rather merges
+	// those into a single "Update" category.
+	Type Type
+
 	// Options declare the options enabled for validation.
+	//
 	// Options should be set according to a resource validation strategy before validation
 	// is performed, and must be treated as read-only during validation.
+	//
 	// Options are identified by string names. Option string names may match the name of a feature
 	// gate, in which case the presence of the name in the set indicates that the feature is
 	// considered enabled for the resource being validated.  Note that a resource may have a
@@ -36,12 +42,12 @@ type Context struct {
 	Options sets.Set[string]
 }
 
-// Operation is the request operation to be validated.
-type Operation uint32
+// Code is the request operation to be validated.
+type Type uint32
 
 const (
 	// Create indicates the request being validated is for a resource create operation.
-	Create Operation = iota
+	Create Type = iota
 
 	// Update indicates the request being validated is for a resource update operation.
 	Update

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/README.md
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/README.md
@@ -13,7 +13,7 @@ import (
         "k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func <Name>(ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, oldValue <ValueType>, <OtherArgs...>) field.ErrorList
+func <Name>(ctx context.Context, op operation.Operation, fldPath *field.Path, value, oldValue <ValueType>, <OtherArgs...>) field.ErrorList
 ```
 
 The name of validator functions should consider that callers will generally be
@@ -45,14 +45,14 @@ Examples:
 
 ```
 // NonEmpty validates that a string is not empty.
-func NonEmpty(ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, _ *string) field.ErrorList
+func NonEmpty(ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList
 
 // Even validates that a slice has an even number of items.
-func Even[T any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, _ []T) field.ErrorList
+func Even[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ []T) field.ErrorList
 
 // KeysMaxLen validates that all of the string keys in a map are under the
 // specified length.
-func KeysMaxLen[T any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, _ map[string]T, maxLen int) field.ErrorList
+func KeysMaxLen[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ map[string]T, maxLen int) field.ErrorList
 ```
 
 Validator functions always return an `ErrorList` where each item is a distinct

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/common.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/common.go
@@ -25,4 +25,4 @@ import (
 
 // ValidateFunc is a function that validates a value, possibly considering the
 // old value (if any).
-type ValidateFunc[T any] func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newValue, oldValue T) field.ErrorList
+type ValidateFunc[T any] func(ctx context.Context, op operation.Operation, fldPath *field.Path, newValue, oldValue T) field.ErrorList

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/doc.go
@@ -19,7 +19,7 @@ limitations under the License.
 // function has a similar fingerprint:
 //
 //	func <Name>(ctx context.Context,
-//	            opCtx operation.Context,
+//	            op operation.Operation,
 //	            fldPath *field.Path,
 //	            value, oldValue <nilable type>,
 //	            <other args...>) field.ErrorList
@@ -36,12 +36,12 @@ limitations under the License.
 // Tightened validation (also known as ratcheting validation) is supported by
 // defining a new validation function. For example:
 //
-//	func TightenedMaxLength(ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, oldValue *string) field.ErrorList {
-//	  if oldValue != nil && len(MaxLength(ctx, opCtx, fldPath, oldValue, nil)) > 0 {
+//	func TightenedMaxLength(ctx context.Context, op operation.Operation, fldPath *field.Path, value, oldValue *string) field.ErrorList {
+//	  if oldValue != nil && len(MaxLength(ctx, op, fldPath, oldValue, nil)) > 0 {
 //	    // old value is not valid, so this value skips the tightened validation
 //	    return nil
 //	  }
-//	  return MaxLength(ctx, opCtx, fldPath, value, nil)
+//	  return MaxLength(ctx, op, fldPath, value, nil)
 //	}
 //
 // In general, we cannot distinguish a non-specified slice or map from one that

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
@@ -30,7 +30,7 @@ type CompareFunc[T any] func(T, T) bool
 // validation function.  The comparison function is used to find the
 // corresponding value in oldSlice.  The value-type of the slices is assumed to
 // not be nilable.
-func EachSliceVal[T any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newSlice, oldSlice []T,
+func EachSliceVal[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, newSlice, oldSlice []T,
 	cmp CompareFunc[T], validator ValidateFunc[*T]) field.ErrorList {
 	var errs field.ErrorList
 	for i, val := range newSlice {
@@ -38,7 +38,7 @@ func EachSliceVal[T any](ctx context.Context, opCtx operation.Context, fldPath *
 		if cmp != nil && len(oldSlice) > 0 {
 			old = lookup(oldSlice, val, cmp)
 		}
-		errs = append(errs, validator(ctx, opCtx, fldPath.Index(i), &val, old)...)
+		errs = append(errs, validator(ctx, op, fldPath.Index(i), &val, old)...)
 	}
 	return errs
 }
@@ -47,7 +47,7 @@ func EachSliceVal[T any](ctx context.Context, opCtx operation.Context, fldPath *
 // validation function.  The comparison function is used to find the
 // corresponding value in oldSlice.  The value-type of the slices is assumed to
 // be nilable.
-func EachSliceValNilable[T any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newSlice, oldSlice []T,
+func EachSliceValNilable[T any](ctx context.Context, op operation.Operation, fldPath *field.Path, newSlice, oldSlice []T,
 	cmp CompareFunc[T], validator ValidateFunc[T]) field.ErrorList {
 	var errs field.ErrorList
 	for i, val := range newSlice {
@@ -58,7 +58,7 @@ func EachSliceValNilable[T any](ctx context.Context, opCtx operation.Context, fl
 				old = *p
 			}
 		}
-		errs = append(errs, validator(ctx, opCtx, fldPath.Index(i), val, old)...)
+		errs = append(errs, validator(ctx, op, fldPath.Index(i), val, old)...)
 	}
 	return errs
 }
@@ -77,7 +77,7 @@ func lookup[T any](list []T, target T, cmp func(T, T) bool) *T {
 // EachMapVal validates each element of newMap with the specified validation
 // function and, if the corresponding key is found in oldMap, the old value.
 // The value-type of the slices is assumed to not be nilable.
-func EachMapVal[K ~string, V any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newMap, oldMap map[K]V,
+func EachMapVal[K ~string, V any](ctx context.Context, op operation.Operation, fldPath *field.Path, newMap, oldMap map[K]V,
 	validator ValidateFunc[*V]) field.ErrorList {
 	var errs field.ErrorList
 	for key, val := range newMap {
@@ -85,7 +85,7 @@ func EachMapVal[K ~string, V any](ctx context.Context, opCtx operation.Context, 
 		if o, found := oldMap[key]; found {
 			old = &o
 		}
-		errs = append(errs, validator(ctx, opCtx, fldPath.Key(string(key)), &val, old)...)
+		errs = append(errs, validator(ctx, op, fldPath.Key(string(key)), &val, old)...)
 	}
 	return errs
 }
@@ -93,7 +93,7 @@ func EachMapVal[K ~string, V any](ctx context.Context, opCtx operation.Context, 
 // EachMapValNilable validates each element of newMap with the specified
 // validation function and, if the corresponding key is found in oldMap, the
 // old value. The value-type of the slices is assumed to be nilable.
-func EachMapValNilable[K ~string, V any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newMap, oldMap map[K]V,
+func EachMapValNilable[K ~string, V any](ctx context.Context, op operation.Operation, fldPath *field.Path, newMap, oldMap map[K]V,
 	validator ValidateFunc[V]) field.ErrorList {
 	var errs field.ErrorList
 	for key, val := range newMap {
@@ -101,19 +101,19 @@ func EachMapValNilable[K ~string, V any](ctx context.Context, opCtx operation.Co
 		if o, found := oldMap[key]; found {
 			old = o
 		}
-		errs = append(errs, validator(ctx, opCtx, fldPath.Key(string(key)), val, old)...)
+		errs = append(errs, validator(ctx, op, fldPath.Key(string(key)), val, old)...)
 	}
 	return errs
 }
 
 // EachMapKey validates each element of newMap with the specified
 // validation function.  The oldMap argument is not used.
-func EachMapKey[K ~string, T any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newMap, oldMap map[K]T,
+func EachMapKey[K ~string, T any](ctx context.Context, op operation.Operation, fldPath *field.Path, newMap, oldMap map[K]T,
 	validator ValidateFunc[*K]) field.ErrorList {
 	var errs field.ErrorList
 	for key := range newMap {
 		// Note: the field path is the field, not the key.
-		errs = append(errs, validator(ctx, opCtx, fldPath, &key, nil)...)
+		errs = append(errs, validator(ctx, op, fldPath, &key, nil)...)
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/each_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/each_test.go
@@ -63,14 +63,14 @@ func testEachSliceVal[T any](t *testing.T, name string, input []T) {
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
 			if oldVal != nil {
 				t.Errorf("expected nil oldVal, got %v", *oldVal)
 			}
 			calls++
 			return nil
 		}
-		_ = EachSliceVal(context.Background(), operation.Context{}, field.NewPath("test"), input, nil, nil, vfn)
+		_ = EachSliceVal(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, nil, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -81,7 +81,7 @@ func testEachSliceValUpdate[T any](t *testing.T, name string, input []T) {
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
 			if oldVal == nil {
 				t.Fatalf("expected non-nil oldVal")
 			}
@@ -95,7 +95,7 @@ func testEachSliceValUpdate[T any](t *testing.T, name string, input []T) {
 		copy(old, input)
 		slices.Reverse(old)
 		cmp := func(a, b T) bool { return reflect.DeepEqual(a, b) }
-		_ = EachSliceVal(context.Background(), operation.Context{}, field.NewPath("test"), input, old, cmp, vfn)
+		_ = EachSliceVal(context.Background(), operation.Operation{}, field.NewPath("test"), input, old, cmp, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -164,14 +164,14 @@ func testEachSliceValNilable[T any](t *testing.T, name string, input []T) {
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
 			if !reflect.DeepEqual(oldVal, zero) {
 				t.Errorf("expected nil oldVal, got %v", oldVal)
 			}
 			calls++
 			return nil
 		}
-		_ = EachSliceValNilable(context.Background(), operation.Context{}, field.NewPath("test"), input, nil, nil, vfn)
+		_ = EachSliceValNilable(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, nil, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -182,7 +182,7 @@ func testEachSliceValNilableUpdate[T any](t *testing.T, name string, input []T) 
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
 			if reflect.DeepEqual(oldVal, zero) {
 				t.Fatalf("expected non-nil oldVal")
 			}
@@ -196,7 +196,7 @@ func testEachSliceValNilableUpdate[T any](t *testing.T, name string, input []T) 
 		copy(old, input)
 		slices.Reverse(old)
 		cmp := func(a, b T) bool { return reflect.DeepEqual(a, b) }
-		_ = EachSliceValNilable(context.Background(), operation.Context{}, field.NewPath("test"), input, old, cmp, vfn)
+		_ = EachSliceValNilable(context.Background(), operation.Operation{}, field.NewPath("test"), input, old, cmp, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -221,14 +221,14 @@ func testEachMapVal[T any](t *testing.T, name string, input map[string]T) {
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal *T) field.ErrorList {
 			if oldVal != nil {
 				t.Errorf("expected nil oldVal, got %v", *oldVal)
 			}
 			calls++
 			return nil
 		}
-		_ = EachMapVal(context.Background(), operation.Context{}, field.NewPath("test"), input, nil, vfn)
+		_ = EachMapVal(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -276,14 +276,14 @@ func testEachMapValNilable[T any](t *testing.T, name string, input map[string]T)
 	var zero T
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal T) field.ErrorList {
 			if !reflect.DeepEqual(oldVal, zero) {
 				t.Errorf("expected nil oldVal, got %v", oldVal)
 			}
 			calls++
 			return nil
 		}
-		_ = EachMapValNilable(context.Background(), operation.Context{}, field.NewPath("test"), input, nil, vfn)
+		_ = EachMapValNilable(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}
@@ -301,14 +301,14 @@ func testEachMapKey[K ~string, V any](t *testing.T, name string, input map[K]V) 
 	var zero K
 	t.Run(fmt.Sprintf("%s(%T)", name, zero), func(t *testing.T) {
 		calls := 0
-		vfn := func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, newVal, oldVal *K) field.ErrorList {
+		vfn := func(ctx context.Context, op operation.Operation, fldPath *field.Path, newVal, oldVal *K) field.ErrorList {
 			if oldVal != nil {
 				t.Errorf("expected nil oldVal, got %v", *oldVal)
 			}
 			calls++
 			return nil
 		}
-		_ = EachMapKey(context.Background(), operation.Context{}, field.NewPath("test"), input, nil, vfn)
+		_ = EachMapKey(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, vfn)
 		if calls != len(input) {
 			t.Errorf("expected %d calls, got %d", len(input), calls)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum.go
@@ -27,7 +27,7 @@ import (
 
 // Enum verifies that the specified value is one of the valid symbols.
 // This is for string enums only.
-func Enum[T ~string](_ context.Context, opCtx operation.Context, fldPath *field.Path, value, _ *T, symbols sets.Set[T]) field.ErrorList {
+func Enum[T ~string](_ context.Context, op operation.Operation, fldPath *field.Path, value, _ *T, symbols sets.Set[T]) field.ErrorList {
 	if value == nil {
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/enum_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/enum_test.go
@@ -41,7 +41,7 @@ func TestEnum(t *testing.T) {
 	}}
 
 	for i, tc := range cases {
-		result := Enum(context.Background(), operation.Context{}, field.NewPath("fldpath"), &tc.value, nil, tc.valid)
+		result := Enum(context.Background(), operation.Operation{}, field.NewPath("fldpath"), &tc.value, nil, tc.valid)
 		if len(result) > 0 && !tc.err {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -85,7 +85,7 @@ func TestEnumTypedef(t *testing.T) {
 	}}
 
 	for i, tc := range cases {
-		result := Enum(context.Background(), operation.Context{}, field.NewPath("fldpath"), &tc.value, nil, tc.valid)
+		result := Enum(context.Background(), operation.Operation{}, field.NewPath("fldpath"), &tc.value, nil, tc.valid)
 		if len(result) > 0 && !tc.err {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
@@ -28,8 +28,8 @@ import (
 // an update operation.  It does nothing if the old value is not provided. If
 // the caller needs to compare types that are not trivially comparable, they
 // should use ImmutableNonComparable instead.
-func Immutable[T comparable](_ context.Context, opCtx operation.Context, fldPath *field.Path, value, oldValue *T) field.ErrorList {
-	if opCtx.Operation != operation.Update {
+func Immutable[T comparable](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue *T) field.ErrorList {
+	if op.Type != operation.Update {
 		return nil
 	}
 	if value == nil && oldValue == nil {
@@ -47,8 +47,8 @@ func Immutable[T comparable](_ context.Context, opCtx operation.Context, fldPath
 // the course of an update operation.  It does nothing if the old value is not
 // provided. Unlike Immutable, this function can be used with types that are
 // not directly comparable, at the cost of performance.
-func ImmutableNonComparable[T any](_ context.Context, opCtx operation.Context, fldPath *field.Path, value, oldValue T) field.ErrorList {
-	if opCtx.Operation != operation.Update {
+func ImmutableNonComparable[T any](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue T) field.ErrorList {
+	if op.Type != operation.Update {
 		return nil
 	}
 	if !equality.Semantic.DeepEqual(value, oldValue) {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable_test.go
@@ -37,76 +37,76 @@ func TestImmutable(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		fn   func(operation.Context, *field.Path) field.ErrorList
+		fn   func(operation.Operation, *field.Path) field.ErrorList
 		fail bool
 	}{{
 		name: "nil both values",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable[int](context.Background(), op, fld, nil, nil)
 		},
 	}, {
 		name: "nil value",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, nil, ptr.To(123))
 		},
 		fail: true,
 	}, {
 		name: "nil oldValue",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(123), nil)
 		},
 		fail: true,
 	}, {
 		name: "int",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(123), ptr.To(123))
 		},
 	}, {
 		name: "int fail",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(123), ptr.To(456))
 		},
 		fail: true,
 	}, {
 		name: "string",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To("abc"), ptr.To("abc"))
 		},
 	}, {
 		name: "string fail",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To("abc"), ptr.To("xyz"))
 		},
 		fail: true,
 	}, {
 		name: "bool",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(true), ptr.To(true))
 		},
 	}, {
 		name: "bool fail",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(true), ptr.To(false))
 		},
 		fail: true,
 	}, {
 		name: "struct",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(structA), ptr.To(structA))
 		},
 	}, {
 		name: "struct fail",
-		fn: func(op operation.Context, fld *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
 			return Immutable(context.Background(), op, fld, ptr.To(structA), ptr.To(structB))
 		},
 		fail: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := tc.fn(operation.Context{Operation: operation.Create}, field.NewPath(""))
+			errs := tc.fn(operation.Operation{Type: operation.Create}, field.NewPath(""))
 			if len(errs) != 0 { // Create should always succeed
 				t.Errorf("case %q (create): expected success: %v", tc.name, errs)
 			}
-			errs = tc.fn(operation.Context{Operation: operation.Update}, field.NewPath(""))
+			errs = tc.fn(operation.Operation{Type: operation.Update}, field.NewPath(""))
 			if tc.fail && len(errs) == 0 {
 				t.Errorf("case %q (update): expected failure", tc.name)
 			} else if !tc.fail && len(errs) != 0 {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
@@ -26,7 +26,7 @@ import (
 
 // MaxLength verifies that the specified value is not longer than max
 // characters.
-func MaxLength[T ~string](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T, max int) field.ErrorList {
+func MaxLength[T ~string](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T, max int) field.ErrorList {
 	if value == nil {
 		return nil
 	}
@@ -37,7 +37,7 @@ func MaxLength[T ~string](_ context.Context, _ operation.Context, fldPath *field
 }
 
 // MaxItems verifies that the specified slice is not longer than max items.
-func MaxItems[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ []T, max int) field.ErrorList {
+func MaxItems[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []T, max int) field.ErrorList {
 	if len(value) > max {
 		return field.ErrorList{field.TooMany(fldPath, len(value), max)}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits_test.go
@@ -52,7 +52,7 @@ func TestMaxLength(t *testing.T) {
 
 	for i, tc := range cases {
 		v := tc.value
-		result := MaxLength(context.Background(), operation.Context{}, field.NewPath("fldpath"), &v, nil, tc.max)
+		result := MaxLength(context.Background(), operation.Operation{}, field.NewPath("fldpath"), &v, nil, tc.max)
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -75,45 +75,45 @@ func TestMaxLength(t *testing.T) {
 
 func TestMaxItems(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := make([]string, 0)
 			max := 0
-			return MaxItems(context.Background(), opCtx, fp, value, nil, max)
+			return MaxItems(context.Background(), op, fp, value, nil, max)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := make([]string, 1)
 			max := 0
-			return MaxItems(context.Background(), opCtx, fp, value, nil, max)
+			return MaxItems(context.Background(), op, fp, value, nil, max)
 		},
 		err: "fldpath: Too many.*must have at most",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := make([]int, 1)
 			max := 1
-			return MaxItems(context.Background(), opCtx, fp, value, nil, max)
+			return MaxItems(context.Background(), op, fp, value, nil, max)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := make([]int, 2)
 			max := 1
-			return MaxItems(context.Background(), opCtx, fp, value, nil, max)
+			return MaxItems(context.Background(), op, fp, value, nil, max)
 		},
 		err: "fldpath: Too many.*must have at most",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := make([]bool, 0)
 			max := -1
-			return MaxItems(context.Background(), opCtx, fp, value, nil, max)
+			return MaxItems(context.Background(), op, fp, value, nil, max)
 		},
 		err: "fldpath: Too many.*too many items",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/net.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/net.go
@@ -27,14 +27,14 @@ import (
 
 // IPSloppy verifies that the specified value is a valid IP address, but allows
 // leading zeros on each octet value.  This should not be used for new APIs.
-func IPSloppy[T ~string](ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func IPSloppy[T ~string](ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	vt := *value
 	vs := string(vt)
-	_, errs := ipSloppy(ctx, opCtx, fldPath, &vs, nil)
+	_, errs := ipSloppy(ctx, op, fldPath, &vs, nil)
 	return errs
 }
 
-func ipSloppy(ctx context.Context, opCtx operation.Context, fldPath *field.Path, value, _ *string) (net.IP, field.ErrorList) {
+func ipSloppy(ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ *string) (net.IP, field.ErrorList) {
 	if value == nil {
 		return nil, nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/net_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/net_test.go
@@ -151,7 +151,7 @@ func TestIPSloppy(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			in := tc.in
-			ip, errs := ipSloppy(context.Background(), operation.Context{}, field.NewPath(""), &in, nil)
+			ip, errs := ipSloppy(context.Background(), operation.Operation{}, field.NewPath(""), &in, nil)
 			if tc.err == "" {
 				if len(errs) != 0 {
 					t.Errorf("%q: expected valid, got: %v", tc.in, errs)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/required.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/required.go
@@ -25,7 +25,7 @@ import (
 
 // RequiredValue verifies that the specified value is not the zero-value for
 // its type.
-func RequiredValue[T comparable](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func RequiredValue[T comparable](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	var zero T
 	if *value != zero {
 		return nil
@@ -34,7 +34,7 @@ func RequiredValue[T comparable](_ context.Context, _ operation.Context, fldPath
 }
 
 // RequiredPointer verifies that the specified pointer is not nil.
-func RequiredPointer[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func RequiredPointer[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	if value != nil {
 		return nil
 	}
@@ -42,7 +42,7 @@ func RequiredPointer[T any](_ context.Context, _ operation.Context, fldPath *fie
 }
 
 // RequiredSlice verifies that the specified slice is not empty.
-func RequiredSlice[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ []T) field.ErrorList {
+func RequiredSlice[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []T) field.ErrorList {
 	if len(value) > 0 {
 		return nil
 	}
@@ -50,7 +50,7 @@ func RequiredSlice[T any](_ context.Context, _ operation.Context, fldPath *field
 }
 
 // RequiredMap verifies that the specified map is not empty.
-func RequiredMap[K comparable, T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
+func RequiredMap[K comparable, T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
 	if len(value) > 0 {
 		return nil
 	}
@@ -59,7 +59,7 @@ func RequiredMap[K comparable, T any](_ context.Context, _ operation.Context, fl
 
 // ForbiddenValue verifies that the specified value is the zero-value for its
 // type.
-func ForbiddenValue[T comparable](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func ForbiddenValue[T comparable](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	var zero T
 	if *value == zero {
 		return nil
@@ -68,7 +68,7 @@ func ForbiddenValue[T comparable](_ context.Context, _ operation.Context, fldPat
 }
 
 // ForbiddenPointer verifies that the specified pointer is nil.
-func ForbiddenPointer[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func ForbiddenPointer[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	if value == nil {
 		return nil
 	}
@@ -76,7 +76,7 @@ func ForbiddenPointer[T any](_ context.Context, _ operation.Context, fldPath *fi
 }
 
 // ForbiddenSlice verifies that the specified slice is empty.
-func ForbiddenSlice[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ []T) field.ErrorList {
+func ForbiddenSlice[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []T) field.ErrorList {
 	if len(value) == 0 {
 		return nil
 	}
@@ -84,7 +84,7 @@ func ForbiddenSlice[T any](_ context.Context, _ operation.Context, fldPath *fiel
 }
 
 // RequiredMap verifies that the specified map is empty.
-func ForbiddenMap[K comparable, T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
+func ForbiddenMap[K comparable, T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
 	if len(value) == 0 {
 		return nil
 	}
@@ -94,7 +94,7 @@ func ForbiddenMap[K comparable, T any](_ context.Context, _ operation.Context, f
 // OptionalValue verifies that the specified value is not the zero-value for
 // its type. This is identical to RequiredValue, but the caller should treat an
 // error here as an indication that the optional value was not specified.
-func OptionalValue[T comparable](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func OptionalValue[T comparable](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	var zero T
 	if *value != zero {
 		return nil
@@ -105,7 +105,7 @@ func OptionalValue[T comparable](_ context.Context, _ operation.Context, fldPath
 // OptionalPointer verifies that the specified pointer is not nil. This is
 // identical to RequiredPointer, but the caller should treat an error here as an
 // indication that the optional value was not specified.
-func OptionalPointer[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func OptionalPointer[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	if value != nil {
 		return nil
 	}
@@ -115,7 +115,7 @@ func OptionalPointer[T any](_ context.Context, _ operation.Context, fldPath *fie
 // OptionalSlice verifies that the specified slice is not empty. This is
 // identical to RequiredSlice, but the caller should treat an error here as an
 // indication that the optional value was not specified.
-func OptionalSlice[T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ []T) field.ErrorList {
+func OptionalSlice[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []T) field.ErrorList {
 	if len(value) > 0 {
 		return nil
 	}
@@ -125,7 +125,7 @@ func OptionalSlice[T any](_ context.Context, _ operation.Context, fldPath *field
 // OptionalMap verifies that the specified map is not empty. This is identical
 // to RequiredMap, but the caller should treat an error here as an indication that
 // the optional value was not specified.
-func OptionalMap[K comparable, T any](_ context.Context, _ operation.Context, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
+func OptionalMap[K comparable, T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ map[K]T) field.ErrorList {
 	if len(value) > 0 {
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/required_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/required_test.go
@@ -28,67 +28,67 @@ import (
 
 func TestRequiredValue(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := "value"
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := "" // zero-value
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 123
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0 // zero-value
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := true
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false // zero-value
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{"value"}
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{} // zero-value
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ptr.To("")
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil) // zero-value
-			return RequiredValue(context.Background(), opCtx, fp, &value, nil)
+			return RequiredValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Required value",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -111,67 +111,67 @@ func TestRequiredValue(t *testing.T) {
 
 func TestRequiredPointer(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ""
-			return RequiredPointer(context.Background(), opCtx, fp, &value, nil)
+			return RequiredPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*string)(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, pointer, nil)
+			return RequiredPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0
-			return RequiredPointer(context.Background(), opCtx, fp, &value, nil)
+			return RequiredPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*int)(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, pointer, nil)
+			return RequiredPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false
-			return RequiredPointer(context.Background(), opCtx, fp, &value, nil)
+			return RequiredPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*bool)(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, pointer, nil)
+			return RequiredPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{}
-			return RequiredPointer(context.Background(), opCtx, fp, &value, nil)
+			return RequiredPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*struct{ S string })(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, pointer, nil)
+			return RequiredPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, &value, nil)
+			return RequiredPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (**string)(nil)
-			return RequiredPointer(context.Background(), opCtx, fp, pointer, nil)
+			return RequiredPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath: Required value",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -194,56 +194,56 @@ func TestRequiredPointer(t *testing.T) {
 
 func TestRequiredSlice(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{""}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{0}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{false}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{nil}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{}
-			return RequiredSlice(context.Background(), opCtx, fp, value, nil)
+			return RequiredSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -266,45 +266,45 @@ func TestRequiredSlice(t *testing.T) {
 
 func TestRequiredMap(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{"": ""}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{0: 0}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[bool]bool{false: false}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]bool{}
-			return RequiredMap(context.Background(), opCtx, fp, value, nil)
+			return RequiredMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Required value",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -327,67 +327,67 @@ func TestRequiredMap(t *testing.T) {
 
 func TestOptionalValue(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := "value"
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := "" // zero-value
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 123
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0 // zero-value
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := true
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false // zero-value
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{"value"}
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{} // zero-value
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ptr.To("")
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil) // zero-value
-			return OptionalValue(context.Background(), opCtx, fp, &value, nil)
+			return OptionalValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -410,67 +410,67 @@ func TestOptionalValue(t *testing.T) {
 
 func TestOptionalPointer(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ""
-			return OptionalPointer(context.Background(), opCtx, fp, &value, nil)
+			return OptionalPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*string)(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, pointer, nil)
+			return OptionalPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0
-			return OptionalPointer(context.Background(), opCtx, fp, &value, nil)
+			return OptionalPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*int)(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, pointer, nil)
+			return OptionalPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false
-			return OptionalPointer(context.Background(), opCtx, fp, &value, nil)
+			return OptionalPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*bool)(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, pointer, nil)
+			return OptionalPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{}
-			return OptionalPointer(context.Background(), opCtx, fp, &value, nil)
+			return OptionalPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*struct{ S string })(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, pointer, nil)
+			return OptionalPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, &value, nil)
+			return OptionalPointer(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (**string)(nil)
-			return OptionalPointer(context.Background(), opCtx, fp, pointer, nil)
+			return OptionalPointer(context.Background(), op, fp, pointer, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -493,56 +493,56 @@ func TestOptionalPointer(t *testing.T) {
 
 func TestOptionalSlice(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{""}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{0}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{false}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{nil}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{}
-			return OptionalSlice(context.Background(), opCtx, fp, value, nil)
+			return OptionalSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -565,45 +565,45 @@ func TestOptionalSlice(t *testing.T) {
 
 func TestOptionalMap(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{"": ""}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{0: 0}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[bool]bool{false: false}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]bool{}
-			return OptionalMap(context.Background(), opCtx, fp, value, nil)
+			return OptionalMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath:.*optional value was not specified",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -626,67 +626,67 @@ func TestOptionalMap(t *testing.T) {
 
 func TestForbiddenValue(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ""
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := "value"
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 123
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := true
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{}
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{"value"}
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil)
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ptr.To("")
-			return ForbiddenValue(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenValue(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -709,67 +709,67 @@ func TestForbiddenValue(t *testing.T) {
 
 func TestForbiddenPointer(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*string)(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, pointer, nil)
+			return ForbiddenPointer(context.Background(), op, fp, pointer, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := ""
-			return ForbiddenPointer(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenPointer(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*int)(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, pointer, nil)
+			return ForbiddenPointer(context.Background(), op, fp, pointer, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := 0
-			return ForbiddenPointer(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenPointer(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*bool)(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, pointer, nil)
+			return ForbiddenPointer(context.Background(), op, fp, pointer, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := false
-			return ForbiddenPointer(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenPointer(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (*struct{ S string })(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, pointer, nil)
+			return ForbiddenPointer(context.Background(), op, fp, pointer, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := struct{ S string }{}
-			return ForbiddenPointer(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenPointer(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			pointer := (**string)(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, pointer, nil)
+			return ForbiddenPointer(context.Background(), op, fp, pointer, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := (*string)(nil)
-			return ForbiddenPointer(context.Background(), opCtx, fp, &value, nil)
+			return ForbiddenPointer(context.Background(), op, fp, &value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -792,56 +792,56 @@ func TestForbiddenPointer(t *testing.T) {
 
 func TestForbiddenSlice(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []string{""}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []int{0}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []bool{false}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := []*string{nil}
-			return ForbiddenSlice(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenSlice(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue
@@ -864,45 +864,45 @@ func TestForbiddenSlice(t *testing.T) {
 
 func TestForbiddenMap(t *testing.T) {
 	cases := []struct {
-		fn  func(opCtx operation.Context, fp *field.Path) field.ErrorList
+		fn  func(op operation.Operation, fp *field.Path) field.ErrorList
 		err string // regex
 	}{{
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]string{"": ""}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[int]int{0: 0}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[string]bool{}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 	}, {
-		fn: func(opCtx operation.Context, fp *field.Path) field.ErrorList {
+		fn: func(op operation.Operation, fp *field.Path) field.ErrorList {
 			value := map[bool]bool{false: false}
-			return ForbiddenMap(context.Background(), opCtx, fp, value, nil)
+			return ForbiddenMap(context.Background(), op, fp, value, nil)
 		},
 		err: "fldpath: Forbidden",
 	}}
 
 	for i, tc := range cases {
-		result := tc.fn(operation.Context{}, field.NewPath("fldpath"))
+		result := tc.fn(operation.Operation{}, field.NewPath("fldpath"))
 		if len(result) > 0 && tc.err == "" {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
@@ -33,7 +33,7 @@ import (
 // All errors returned by this function will be "invalid" type errors. If the
 // caller wants better errors, it must take responsibility for checking things
 // like required/optional and max-length.
-func DNSLabel[T ~string](_ context.Context, opCtx operation.Context, fldPath *field.Path, value, _ *T) field.ErrorList {
+func DNSLabel[T ~string](_ context.Context, op operation.Operation, fldPath *field.Path, value, _ *T) field.ErrorList {
 	if value == nil {
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/subfield.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/subfield.go
@@ -28,7 +28,7 @@ import (
 type GetFieldFunc[Tstruct any, Tfield any] func(*Tstruct) Tfield
 
 // Subfield validates a subfield of a struct against a validator function.
-func Subfield[Tstruct any, Tfield any](ctx context.Context, opCtx operation.Context, fldPath *field.Path, newStruct, oldStruct *Tstruct,
+func Subfield[Tstruct any, Tfield any](ctx context.Context, op operation.Operation, fldPath *field.Path, newStruct, oldStruct *Tstruct,
 	fldName string, getField GetFieldFunc[Tstruct, Tfield], validator ValidateFunc[Tfield]) field.ErrorList {
 	var errs field.ErrorList
 	newVal := getField(newStruct)
@@ -36,6 +36,6 @@ func Subfield[Tstruct any, Tfield any](ctx context.Context, opCtx operation.Cont
 	if oldStruct != nil {
 		oldVal = getField(oldStruct)
 	}
-	errs = append(errs, validator(ctx, opCtx, fldPath.Child(fldName), newVal, oldVal)...)
+	errs = append(errs, validator(ctx, op, fldPath.Child(fldName), newVal, oldVal)...)
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/testing.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/testing.go
@@ -25,7 +25,7 @@ import (
 
 // FixedResult asserts a fixed boolean result.  This is mostly useful for
 // testing.
-func FixedResult[T any](_ context.Context, opCtx operation.Context, fldPath *field.Path, value, _ T, result bool, arg string) field.ErrorList {
+func FixedResult[T any](_ context.Context, op operation.Operation, fldPath *field.Path, value, _ T, result bool, arg string) field.ErrorList {
 	if result {
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/testing_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/testing_test.go
@@ -122,7 +122,7 @@ func TestFixedResult(t *testing.T) {
 	}}
 
 	for i, tc := range cases {
-		result := FixedResult(context.Background(), operation.Context{}, field.NewPath("fldpath"), tc.value, nil, tc.pass, "detail string")
+		result := FixedResult(context.Background(), operation.Operation{}, field.NewPath("fldpath"), tc.value, nil, tc.pass, "detail string")
 		if len(result) != 0 && tc.pass {
 			t.Errorf("case %d: unexpected failure: %v", i, fmtErrs(result))
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
@@ -33,11 +33,11 @@ import (
 // For example:
 //
 //	var abcUnionMembership := schema.NewUnionMembership("a", "b", "c")
-//	func ValidateABC(ctx context.Context, opCtx operation.Context, fldPath *field.Path, in *ABC) (errs fields.ErrorList) {
-//		errs = append(errs, Union(ctx, opCtx, fldPath, in, abcUnionMembership, in.A, in.B, in.C)...)
+//	func ValidateABC(ctx context.Context, op operation.Operation, fldPath *field.Path, in *ABC) (errs fields.ErrorList) {
+//		errs = append(errs, Union(ctx, op, fldPath, in, abcUnionMembership, in.A, in.B, in.C)...)
 //		return errs
 //	}
-func Union(_ context.Context, opCtx operation.Context, fldPath *field.Path, _, _ any, union *UnionMembership, fieldValues ...any) field.ErrorList {
+func Union(_ context.Context, op operation.Operation, fldPath *field.Path, _, _ any, union *UnionMembership, fieldValues ...any) field.ErrorList {
 	if len(union.members) != len(fieldValues) {
 		return field.ErrorList{
 			field.InternalError(fldPath,
@@ -75,14 +75,14 @@ func Union(_ context.Context, opCtx operation.Context, fldPath *field.Path, _, _
 // For example:
 //
 //	var abcUnionMembership := schema.NewDiscriminatedUnionMembership("type", "a", "b", "c")
-//	func ValidateABC(ctx context.Context, opCtx operation.Context, fldPath, *field.Path, in *ABC) (errs fields.ErrorList) {
-//		errs = append(errs, DiscriminatedUnion(ctx, opCtx, fldPath, in, abcUnionMembership, in.Type, in.A, in.B, in.C)...)
+//	func ValidateABC(ctx context.Context, op operation.Operation, fldPath, *field.Path, in *ABC) (errs fields.ErrorList) {
+//		errs = append(errs, DiscriminatedUnion(ctx, op, fldPath, in, abcUnionMembership, in.Type, in.A, in.B, in.C)...)
 //		return errs
 //	}
 //
 // It is not an error for the discriminatorValue to be unknown.  That must be
 // validated on its own.
-func DiscriminatedUnion[T ~string](_ context.Context, opCtx operation.Context, fldPath *field.Path, _, _ any, union *UnionMembership, discriminatorValue T, fieldValues ...any) (errs field.ErrorList) {
+func DiscriminatedUnion[T ~string](_ context.Context, op operation.Operation, fldPath *field.Path, _, _ any, union *UnionMembership, discriminatorValue T, fieldValues ...any) (errs field.ErrorList) {
 	discriminatorStrValue := string(discriminatorValue)
 	if len(union.members) != len(fieldValues) {
 		return field.ErrorList{

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
@@ -81,7 +81,7 @@ func TestUnion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Union(context.Background(), operation.Context{Operation: operation.Update}, nil, nil, nil, NewUnionMembership(tc.fields...), tc.fieldValues...)
+			got := Union(context.Background(), operation.Operation{Type: operation.Update}, nil, nil, nil, NewUnionMembership(tc.fields...), tc.fieldValues...)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("got %v want %v", got, tc.expected)
 			}
@@ -120,7 +120,7 @@ func TestDiscriminatedUnion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DiscriminatedUnion(context.Background(), operation.Context{Operation: operation.Update}, nil, nil, nil, NewDiscriminatedUnionMembership(tc.discriminatorField, tc.fields...), tc.discriminatorValue, tc.fieldValues...)
+			got := DiscriminatedUnion(context.Background(), operation.Operation{Type: operation.Update}, nil, nil, nil, NewDiscriminatedUnionMembership(tc.discriminatorField, tc.fields...), tc.discriminatorValue, tc.fieldValues...)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("got %v want %v", got.ToAggregate(), tc.expected.ToAggregate())
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -74,7 +74,7 @@ type Scheme struct {
 	// The provided object must be a pointer.
 	// If oldObject is non-nil, update validation is performed and may perform additional
 	// validation such as transition rules and immutability checks.
-	validationFuncs map[reflect.Type]func(opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList
+	validationFuncs map[reflect.Type]func(op operation.Operation, object, oldObject interface{}, subresources ...string) field.ErrorList
 
 	// converter stores all registered conversion functions. It also has
 	// default converting behavior.
@@ -104,7 +104,7 @@ func NewScheme() *Scheme {
 		unversionedKinds:          map[string]reflect.Type{},
 		fieldLabelConversionFuncs: map[schema.GroupVersionKind]FieldLabelConversionFunc{},
 		defaulterFuncs:            map[reflect.Type]func(interface{}){},
-		validationFuncs:           map[reflect.Type]func(opCtx operation.Context, object, oldObject interface{}, subresource ...string) field.ErrorList{},
+		validationFuncs:           map[reflect.Type]func(op operation.Operation, object, oldObject interface{}, subresource ...string) field.ErrorList{},
 		versionPriority:           map[string][]string{},
 		schemeName:                naming.GetNameFromCallsite(internalPackages...),
 	}
@@ -360,7 +360,7 @@ func (s *Scheme) Default(src Object) {
 // These functions will be invoked  when Validate() is called. The function will never
 // be called unless the validated object matches srcType. If this function is invoked
 // twice with the same srcType, the fn passed to the later call will be used instead.
-func (s *Scheme) AddValidationFunc(srcType Object, fn func(opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList) {
+func (s *Scheme) AddValidationFunc(srcType Object, fn func(op operation.Operation, object, oldObject interface{}, subresources ...string) field.ErrorList) {
 	s.validationFuncs[reflect.TypeOf(srcType)] = fn
 }
 
@@ -369,7 +369,7 @@ func (s *Scheme) AddValidationFunc(srcType Object, fn func(opCtx operation.Conte
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
 func (s *Scheme) Validate(options sets.Set[string], object Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(operation.Context{Operation: operation.Create, Options: options}, object, nil, subresources...)
+		return fn(operation.Operation{Type: operation.Create, Options: options}, object, nil, subresources...)
 	}
 	return nil
 }
@@ -379,7 +379,7 @@ func (s *Scheme) Validate(options sets.Set[string], object Object, subresources 
 // is not run when this is called.  Only the generated zz_generated.validations.go validation code is run.
 func (s *Scheme) ValidateUpdate(options sets.Set[string], object, oldObject Object, subresources ...string) field.ErrorList {
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(operation.Context{Operation: operation.Update, Options: options}, oldObject, object, subresources...)
+		return fn(operation.Operation{Type: operation.Update, Options: options}, oldObject, object, subresources...)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -303,7 +303,7 @@ func IsValidPortName(port string) []string {
 
 // IsValidIP tests that the argument is a valid IP address.
 func IsValidIP(fldPath *field.Path, value string) field.ErrorList {
-	return validate.IPSloppy(context.TODO(), operation.Context{}, fldPath, &value, nil)
+	return validate.IPSloppy(context.TODO(), operation.Operation{}, fldPath, &value, nil)
 }
 
 // IsValidIPv4Address tests that the argument is a valid IPv4 address.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_field_validations/zz_generated.validations.go
@@ -37,69 +37,69 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T2)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T2)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T2(ctx, opCtx, nil /* fldPath */, obj.(*T2), safe.Cast[*T2](oldObj))
+			return Validate_T2(ctx, op, nil /* fldPath */, obj.(*T2), safe.Cast[*T2](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T4)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T4)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T4(ctx, opCtx, nil /* fldPath */, obj.(*T4), safe.Cast[*T4](oldObj))
+			return Validate_T4(ctx, op, nil /* fldPath */, obj.(*T4), safe.Cast[*T4](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.S }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
 	// field T1.T3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T3")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T3")...)
 			return
 		}(fldPath.Child("t3"), &obj.T3, safe.Field(oldObj, func(oldObj *T1) *T3 { return &oldObj.T3 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// field T2.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T2) *string { return &oldObj.S }))...)
 
 	return errs
 }
 
-func Validate_T4(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T4) (errs field.ErrorList) {
+func Validate_T4(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T4) (errs field.ErrorList) {
 	// field T4.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T4.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T4.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T4) *string { return &oldObj.S }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/all_types_match/with_type_validations/zz_generated.validations.go
@@ -37,36 +37,36 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*E1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*E1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_E1(ctx, opCtx, nil /* fldPath */, obj.(*E1), safe.Cast[*E1](oldObj))
+			return Validate_E1(ctx, op, nil /* fldPath */, obj.(*E1), safe.Cast[*E1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
+func Validate_E1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
 	// type E1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1")...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// type T1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1")...)
 
 	// field T1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.S }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
@@ -40,77 +40,77 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.PrimitivesT1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *primitives.T1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.PrimitivesT1")...)
-			errs = append(errs, primitives.Validate_T1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.PrimitivesT1")...)
+			errs = append(errs, primitives.Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("primitivest1"), &obj.PrimitivesT1, safe.Field(oldObj, func(oldObj *T1) *primitives.T1 { return &oldObj.PrimitivesT1 }))...)
 
 	// field T1.PrimitivesT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *primitives.T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.PrimitivesT2")...)
-			errs = append(errs, primitives.Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.PrimitivesT2")...)
+			errs = append(errs, primitives.Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("primitivest2"), &obj.PrimitivesT2, safe.Field(oldObj, func(oldObj *T1) *primitives.T2 { return &oldObj.PrimitivesT2 }))...)
 
 	// field T1.PrimitivesT3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *primitives.T3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.PrimitivesT3")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.PrimitivesT3")...)
 			return
 		}(fldPath.Child("primitivest3"), &obj.PrimitivesT3, safe.Field(oldObj, func(oldObj *T1) *primitives.T3 { return &oldObj.PrimitivesT3 }))...)
 
 	// field T1.TypedefsE1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *typedefs.E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.TypedefsE1")...)
-			errs = append(errs, typedefs.Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.TypedefsE1")...)
+			errs = append(errs, typedefs.Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("typedefse1"), &obj.TypedefsE1, safe.Field(oldObj, func(oldObj *T1) *typedefs.E1 { return &oldObj.TypedefsE1 }))...)
 
 	// field T1.TypedefsE2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *typedefs.E2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.TypedefsE2")...)
-			errs = append(errs, typedefs.Validate_E2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.TypedefsE2")...)
+			errs = append(errs, typedefs.Validate_E2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("typedefse2"), &obj.TypedefsE2, safe.Field(oldObj, func(oldObj *T1) *typedefs.E2 { return &oldObj.TypedefsE2 }))...)
 
 	// field T1.TypedefsE3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *typedefs.E3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.TypedefsE3")...)
-			errs = append(errs, typedefs.Validate_E3(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.TypedefsE3")...)
+			errs = append(errs, typedefs.Validate_E3(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("typedefse3"), &obj.TypedefsE3, safe.Field(oldObj, func(oldObj *T1) *typedefs.E3 { return &oldObj.TypedefsE3 }))...)
 
 	// field T1.TypedefsE4
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *typedefs.E4) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.TypedefsE4")...)
-			errs = append(errs, typedefs.Validate_E4(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.TypedefsE4")...)
+			errs = append(errs, typedefs.Validate_E4(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("typedefse4"), &obj.TypedefsE4, safe.Field(oldObj, func(oldObj *T1) *typedefs.E4 { return &oldObj.TypedefsE4 }))...)
 
 	// field T1.OtherString
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *other.StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.OtherString")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.OtherString")...)
 			// NOTE: Not validating this field's type: other.StringType is in a non-included package.
 			return
 		}(fldPath.Child("otherString"), &obj.OtherString, safe.Field(oldObj, func(oldObj *T1) *other.StringType { return &oldObj.OtherString }))...)
@@ -118,7 +118,7 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.OtherInt
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *other.IntType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.OtherInt")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.OtherInt")...)
 			// NOTE: Not validating this field's type: other.IntType is in a non-included package.
 			return
 		}(fldPath.Child("otherInt"), &obj.OtherInt, safe.Field(oldObj, func(oldObj *T1) *other.IntType { return &oldObj.OtherInt }))...)
@@ -126,7 +126,7 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.OtherStruct
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *other.StructType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.OtherStruct")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.OtherStruct")...)
 			// NOTE: Not validating this field's type: other.StructType is in a non-included package.
 			return
 		}(fldPath.Child("otherStruct"), &obj.OtherStruct, safe.Field(oldObj, func(oldObj *T1) *other.StructType { return &oldObj.OtherStruct }))...)
@@ -134,9 +134,9 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.SliceOfOtherStruct
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []other.StructType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.SliceOfOtherStruct")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *other.StructType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.SliceOfOtherStruct values")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.SliceOfOtherStruct")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *other.StructType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.SliceOfOtherStruct values")
 			})...)
 			// NOTE: Not iterating this list's values: StructType is in a non-included package.
 			return
@@ -145,12 +145,12 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.MapOfOtherStringToOtherStruct
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[other.StringType]other.StructType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *other.StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct keys")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *other.StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct keys")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *other.StructType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct values")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *other.StructType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.MapOfOtherStringToOtherStruct values")
 			})...)
 			// NOTE: Not iterating this map's keys: StringType is in a non-included package.
 			// NOTE: Not iterating this map's values: StructType is in a non-included package.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/elide_no_validations/zz_generated.validations.go
@@ -37,48 +37,48 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_HasFieldVal(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *HasFieldVal) (errs field.ErrorList) {
+func Validate_HasFieldVal(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *HasFieldVal) (errs field.ErrorList) {
 	// field HasFieldVal.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field HasFieldVal.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field HasFieldVal.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *HasFieldVal) *string { return &oldObj.S }))...)
 
 	return errs
 }
 
-func Validate_HasTypeVal(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *HasTypeVal) (errs field.ErrorList) {
+func Validate_HasTypeVal(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *HasTypeVal) (errs field.ErrorList) {
 	// type HasTypeVal
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type HasTypeVal")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type HasTypeVal")...)
 
 	// field HasTypeVal.S has no validation
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.HasTypeVal
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *HasTypeVal) (errs field.ErrorList) {
-			errs = append(errs, Validate_HasTypeVal(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_HasTypeVal(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("hasTypeVal"), &obj.HasTypeVal, safe.Field(oldObj, func(oldObj *T1) *HasTypeVal { return &oldObj.HasTypeVal }))...)
 
 	// field T1.HasFieldVal
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *HasFieldVal) (errs field.ErrorList) {
-			errs = append(errs, Validate_HasFieldVal(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_HasFieldVal(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("hasFieldVal"), &obj.HasFieldVal, safe.Field(oldObj, func(oldObj *T1) *HasFieldVal { return &oldObj.HasFieldVal }))...)
 
@@ -87,7 +87,7 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.HasNoValFieldVal
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *HasNoVal) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.HasNoValFieldVal")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.HasNoValFieldVal")...)
 			return
 		}(fldPath.Child("hasNoValFieldVal"), &obj.HasNoValFieldVal, safe.Field(oldObj, func(oldObj *T1) *HasNoVal { return &oldObj.HasNoValFieldVal }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/zz_generated.validations.go
@@ -37,89 +37,89 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField(keys)")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[UnvalidatedStringType]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *UnvalidatedStringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *UnvalidatedStringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField(keys)")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[UnvalidatedStringType]string { return oldObj.MapTypedefField }))...)
 
 	// field Struct.MapValidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[ValidatedStringType]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *ValidatedStringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapValidatedTypedefField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ValidatedStringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapValidatedTypedefField(keys)")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapValidatedTypedefField")...)
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, Validate_ValidatedStringType)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapValidatedTypedefField")...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, Validate_ValidatedStringType)...)
 			return
 		}(fldPath.Child("mapValidatedTypedefField"), obj.MapValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[ValidatedStringType]string { return oldObj.MapValidatedTypedefField }))...)
 
 	// field Struct.MapTypeField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj UnvalidatedMapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypeField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypeField(keys)")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypeField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypeField")...)
 			return
 		}(fldPath.Child("mapTypeField"), obj.MapTypeField, safe.Field(oldObj, func(oldObj *Struct) UnvalidatedMapType { return oldObj.MapTypeField }))...)
 
 	// field Struct.ValidatedMapTypeField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ValidatedMapTypeField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ValidatedMapTypeField(keys)")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ValidatedMapTypeField")...)
-			errs = append(errs, Validate_ValidatedMapType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ValidatedMapTypeField")...)
+			errs = append(errs, Validate_ValidatedMapType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("validatedMapTypeField"), obj.ValidatedMapTypeField, safe.Field(oldObj, func(oldObj *Struct) ValidatedMapType { return oldObj.ValidatedMapTypeField }))...)
 
 	return errs
 }
 
-func Validate_ValidatedMapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
+func Validate_ValidatedMapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
 	// type ValidatedMapType
-	errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ValidatedMapType(keys)")
+	errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ValidatedMapType(keys)")
 	})...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "ValidatedMapType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "ValidatedMapType")...)
 
 	return errs
 }
 
-func Validate_ValidatedStringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *ValidatedStringType) (errs field.ErrorList) {
+func Validate_ValidatedStringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ValidatedStringType) (errs field.ErrorList) {
 	// type ValidatedStringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "ValidatedStringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "ValidatedStringType")...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_map/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_map/deep/zz_generated.validations.go
@@ -37,38 +37,38 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
 				})
 			})...)
 			return
@@ -77,10 +77,10 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
 				})
 			})...)
 			return
@@ -89,13 +89,13 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
 				})
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_MapType)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_MapType)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]MapType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_map/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_map/shallow/zz_generated.validations.go
@@ -37,40 +37,40 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]map[string]string { return oldObj.MapField }))...)
@@ -78,9 +78,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]map[string]*string { return oldObj.MapPtrField }))...)
@@ -88,11 +88,11 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_MapType)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_MapType)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]MapType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/zz_generated.validations.go
@@ -37,34 +37,34 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
@@ -72,9 +72,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*string { return oldObj.MapPtrField }))...)
@@ -82,22 +82,22 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]StringType { return oldObj.MapTypedefField }))...)
 
 	// field Struct.MapTypedefPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 			return
 		}(fldPath.Child("mapTypedefPtrField"), obj.MapTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*StringType { return oldObj.MapTypedefPtrField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_slice/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_slice/deep/zz_generated.validations.go
@@ -37,46 +37,46 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_SliceType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
 	// type SliceType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListType[*]")
 	})...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
 				})
 			})...)
 			return
@@ -85,10 +85,10 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
 				})
 			})...)
 			return
@@ -97,13 +97,13 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
 				})
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_SliceType)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_SliceType)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]SliceType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_slice/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_slice/shallow/zz_generated.validations.go
@@ -37,37 +37,37 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_SliceType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
 	// type SliceType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string][]string { return oldObj.MapField }))...)
@@ -75,9 +75,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string][]*string { return oldObj.MapPtrField }))...)
@@ -85,11 +85,11 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_SliceType)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_SliceType)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]SliceType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/zz_generated.validations.go
@@ -37,76 +37,76 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_OtherStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
+func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
 
 	return errs
 }
 
-func Validate_OtherTypedefStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) (errs field.ErrorList) {
+func Validate_OtherTypedefStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) (errs field.ErrorList) {
 	// type OtherTypedefStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherTypedefStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherTypedefStruct")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_OtherStruct)...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_OtherStruct)...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]OtherStruct { return oldObj.MapField }))...)
 
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_OtherStruct)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_OtherStruct)...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*OtherStruct { return oldObj.MapPtrField }))...)
 
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_OtherTypedefStruct)...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_OtherTypedefStruct)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]OtherTypedefStruct { return oldObj.MapTypedefField }))...)
 
 	// field Struct.MapTypedefPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, Validate_OtherTypedefStruct)...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, Validate_OtherTypedefStruct)...)
 			return
 		}(fldPath.Child("mapTypedefPtrField"), obj.MapTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*OtherTypedefStruct { return oldObj.MapTypedefPtrField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/zz_generated.validations.go
@@ -37,37 +37,37 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField(keys) #1")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField(keys) #1")
 			})...)
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField(keys) #2")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField(keys) #2")
 			})...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField #1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField #2")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*] #1")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField #1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField #2")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*] #1")
 			})...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*] #2")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*] #2")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/zz_generated.validations.go
@@ -37,89 +37,89 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapPtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
+func Validate_MapPtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
 	// type MapPtrType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapPtrType")...)
-	errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapPtrType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapPtrType")...)
+	errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapPtrType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_MapTypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
+func Validate_MapTypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
 	// type MapTypedefType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapTypedefType")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapTypedefType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapTypedefType")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapTypedefType[*]")
 	})...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
-			errs = append(errs, Validate_MapType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) MapType { return oldObj.MapField }))...)
 
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField")...)
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
-			errs = append(errs, Validate_MapPtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapPtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) MapPtrType { return oldObj.MapPtrField }))...)
 
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, Validate_MapTypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapTypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) MapTypedefType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/multiple_tags/zz_generated.validations.go
@@ -37,60 +37,60 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// type T1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1 #1")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1 #2")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1 #3")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "type T1 #0")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1 #1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1 #2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1 #3")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "type T1 #0")...)
 
 	// field T1.TypeMeta has no validation
 
 	// field T1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S false #1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S false #2")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S false #3")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.S true")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S false #1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S false #2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S false #3")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.S true")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.S }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2 false #1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2 false #2")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2 false #3")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T1.T2 true")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2 false #1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2 false #2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2 false #3")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.T2 true")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// type T2
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T2 false #1")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T2 false #2")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "type T2 true")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T2 false #1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T2 false #2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "type T2 true")...)
 
 	// field T2.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S false #1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S false #2")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field T2.S true")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S false #1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S false #2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T2.S true")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T2) *string { return &oldObj.S }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_field_validations/zz_generated.validations.go
@@ -37,70 +37,70 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
+func Validate_E1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
 	// type E1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1")...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.S }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
 	// field T1.T3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T3")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T3")...)
 			return
 		}(fldPath.Child("t3"), &obj.T3, safe.Field(oldObj, func(oldObj *T1) *T3 { return &oldObj.T3 }))...)
 
 	// field T1.E1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E1")...)
-			errs = append(errs, Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E1")...)
+			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e1"), &obj.E1, safe.Field(oldObj, func(oldObj *T1) *E1 { return &oldObj.E1 }))...)
 
 	// field T1.E2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E2")...)
 			return
 		}(fldPath.Child("e2"), &obj.E2, safe.Field(oldObj, func(oldObj *T1) *E2 { return &oldObj.E2 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// field T2.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T2) *string { return &oldObj.S }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/one_type_match/with_type_validations/zz_generated.validations.go
@@ -37,18 +37,18 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// type T1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1")...)
 
 	// field T1.TypeMeta has no validation
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
@@ -37,40 +37,40 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T00)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T00)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T00(ctx, opCtx, nil /* fldPath */, obj.(*T00), safe.Cast[*T00](oldObj))
+			return Validate_T00(ctx, op, nil /* fldPath */, obj.(*T00), safe.Cast[*T00](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T01)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T01)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T01(ctx, opCtx, nil /* fldPath */, obj.(*T01), safe.Cast[*T01](oldObj))
+			return Validate_T01(ctx, op, nil /* fldPath */, obj.(*T01), safe.Cast[*T01](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T02)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T02)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T02(ctx, opCtx, nil /* fldPath */, obj.(*T02), safe.Cast[*T02](oldObj))
+			return Validate_T02(ctx, op, nil /* fldPath */, obj.(*T02), safe.Cast[*T02](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T03)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T03)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T03(ctx, opCtx, nil /* fldPath */, obj.(*T03), safe.Cast[*T03](oldObj))
+			return Validate_T03(ctx, op, nil /* fldPath */, obj.(*T03), safe.Cast[*T03](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*TMultiple)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*TMultiple)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_TMultiple(ctx, opCtx, nil /* fldPath */, obj.(*TMultiple), safe.Cast[*TMultiple](oldObj))
+			return Validate_TMultiple(ctx, op, nil /* fldPath */, obj.(*TMultiple), safe.Cast[*TMultiple](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T00(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T00) (errs field.ErrorList) {
+func Validate_T00(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T00) (errs field.ErrorList) {
 	// field T00.TypeMeta has no validation
 	// field T00.S has no validation
 	// field T00.PS has no validation
@@ -78,62 +78,62 @@ func Validate_T00(ctx context.Context, opCtx operation.Context, fldPath *field.P
 	// field T00.T
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t"), &obj.T, safe.Field(oldObj, func(oldObj *T00) *Tother { return &oldObj.T }))...)
 
 	// field T00.PT
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt"), obj.PT, safe.Field(oldObj, func(oldObj *T00) *Tother { return oldObj.PT }))...)
 
 	return errs
 }
 
-func Validate_T01(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T01) (errs field.ErrorList) {
+func Validate_T01(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T01) (errs field.ErrorList) {
 	// type T01
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T01, no flags")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T01, no flags")...)
 
 	// field T01.TypeMeta has no validation
 
 	// field T01.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T01.S, no flags")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T01.S, no flags")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T01) *string { return &oldObj.S }))...)
 
 	// field T01.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T01.PS, no flags")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T01.PS, no flags")...)
 			return
 		}(fldPath.Child("ps"), obj.PS, safe.Field(oldObj, func(oldObj *T01) *string { return oldObj.PS }))...)
 
 	// field T01.T
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T01.T, no flags")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T01.T, no flags")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t"), &obj.T, safe.Field(oldObj, func(oldObj *T01) *Tother { return &oldObj.T }))...)
 
 	// field T01.PT
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T01.PT, no flags")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T01.PT, no flags")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt"), obj.PT, safe.Field(oldObj, func(oldObj *T01) *Tother { return oldObj.PT }))...)
 
 	return errs
 }
 
-func Validate_T02(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T02) (errs field.ErrorList) {
+func Validate_T02(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T02) (errs field.ErrorList) {
 	// type T02
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T02, ShortCircuit"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02, ShortCircuit"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -143,7 +143,7 @@ func Validate_T02(ctx context.Context, opCtx operation.Context, fldPath *field.P
 	// field T02.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T02.S, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.S, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -153,7 +153,7 @@ func Validate_T02(ctx context.Context, opCtx operation.Context, fldPath *field.P
 	// field T02.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T02.PS, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.PS, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -163,181 +163,181 @@ func Validate_T02(ctx context.Context, opCtx operation.Context, fldPath *field.P
 	// field T02.T
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T02.T, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.T, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t"), &obj.T, safe.Field(oldObj, func(oldObj *T02) *Tother { return &oldObj.T }))...)
 
 	// field T02.PT
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T02.PT, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.PT, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt"), obj.PT, safe.Field(oldObj, func(oldObj *T02) *Tother { return oldObj.PT }))...)
 
 	return errs
 }
 
-func Validate_T03(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T03) (errs field.ErrorList) {
+func Validate_T03(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T03) (errs field.ErrorList) {
 	// type T03
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03, ShortCircuit"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03, ShortCircuit"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03, no flags")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03, no flags")...)
 
 	// field T03.TypeMeta has no validation
 
 	// field T03.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.S, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.S, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.S, no flags")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.S, no flags")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T03) *string { return &oldObj.S }))...)
 
 	// field T03.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.PS, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PS, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.PS, no flags")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PS, no flags")...)
 			return
 		}(fldPath.Child("ps"), obj.PS, safe.Field(oldObj, func(oldObj *T03) *string { return oldObj.PS }))...)
 
 	// field T03.T
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.T, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.T, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.T, no flags")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.T, no flags")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t"), &obj.T, safe.Field(oldObj, func(oldObj *T03) *Tother { return &oldObj.T }))...)
 
 	// field T03.PT
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.PT, ShortCircuit"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PT, ShortCircuit"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T03.PT, no flags")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PT, no flags")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt"), obj.PT, safe.Field(oldObj, func(oldObj *T03) *Tother { return oldObj.PT }))...)
 
 	return errs
 }
 
-func Validate_TMultiple(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *TMultiple) (errs field.ErrorList) {
+func Validate_TMultiple(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *TMultiple) (errs field.ErrorList) {
 	// type TMultiple
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple, ShortCircuit 1"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple, ShortCircuit 1"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple, ShortCircuit 2"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple, ShortCircuit 2"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple, no flags 1")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T0, string payload")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple, no flags 2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple, no flags 1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T0, string payload")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple, no flags 2")...)
 
 	// field TMultiple.TypeMeta has no validation
 
 	// field TMultiple.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.S, ShortCircuit 1"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.S, ShortCircuit 1"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.S, ShortCircuit 2"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.S, ShortCircuit 2"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.S, no flags 1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T0, string payload")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.S, no flags 2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.S, no flags 1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T0, string payload")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.S, no flags 2")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *TMultiple) *string { return &oldObj.S }))...)
 
 	// field TMultiple.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PS, ShortCircuit 1"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PS, ShortCircuit 1"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PS, ShortCircuit 2"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PS, ShortCircuit 2"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PS, no flags 1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T0, string payload")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PS, no flags 2")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PS, no flags 1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T0, string payload")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PS, no flags 2")...)
 			return
 		}(fldPath.Child("ps"), obj.PS, safe.Field(oldObj, func(oldObj *TMultiple) *string { return oldObj.PS }))...)
 
 	// field TMultiple.T
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.T, ShortCircuit 1"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.T, ShortCircuit 1"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.T, ShortCircuit 2"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.T, ShortCircuit 2"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.T, no flags 1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T0, string payload")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.T, no flags 2")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.T, no flags 1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T0, string payload")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.T, no flags 2")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t"), &obj.T, safe.Field(oldObj, func(oldObj *TMultiple) *Tother { return &oldObj.T }))...)
 
 	// field TMultiple.PT
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PT, ShortCircuit 1"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PT, ShortCircuit 1"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PT, ShortCircuit 2"); len(e) != 0 {
+			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PT, ShortCircuit 2"); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PT, no flags 1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "T0, string payload")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "TMultiple.PT, no flags 2")...)
-			errs = append(errs, Validate_Tother(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PT, no flags 1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T0, string payload")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PT, no flags 2")...)
+			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt"), obj.PT, safe.Field(oldObj, func(oldObj *TMultiple) *Tother { return oldObj.PT }))...)
 
 	return errs
 }
 
-func Validate_Tother(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
+func Validate_Tother(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Tother) (errs field.ErrorList) {
 	// field Tother.OS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Tother, no flags")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Tother, no flags")...)
 			return
 		}(fldPath.Child("os"), &obj.OS, safe.Field(oldObj, func(oldObj *Tother) *string { return &oldObj.OS }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
@@ -37,43 +37,43 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*E01)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*E01)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_E01(ctx, opCtx, nil /* fldPath */, obj.(*E01), safe.Cast[*E01](oldObj))
+			return Validate_E01(ctx, op, nil /* fldPath */, obj.(*E01), safe.Cast[*E01](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*E02)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*E02)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_E02(ctx, opCtx, nil /* fldPath */, obj.(*E02), safe.Cast[*E02](oldObj))
+			return Validate_E02(ctx, op, nil /* fldPath */, obj.(*E02), safe.Cast[*E02](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*E03)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*E03)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_E03(ctx, opCtx, nil /* fldPath */, obj.(*E03), safe.Cast[*E03](oldObj))
+			return Validate_E03(ctx, op, nil /* fldPath */, obj.(*E03), safe.Cast[*E03](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*EMultiple)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*EMultiple)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_EMultiple(ctx, opCtx, nil /* fldPath */, obj.(*EMultiple), safe.Cast[*EMultiple](oldObj))
+			return Validate_EMultiple(ctx, op, nil /* fldPath */, obj.(*EMultiple), safe.Cast[*EMultiple](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E01(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E01) (errs field.ErrorList) {
+func Validate_E01(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E01) (errs field.ErrorList) {
 	// type E01
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "E01, no flags")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E01, no flags")...)
 
 	return errs
 }
 
-func Validate_E02(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E02) (errs field.ErrorList) {
+func Validate_E02(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E02) (errs field.ErrorList) {
 	// type E02
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "E02, ShortCircuit"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E02, ShortCircuit"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -81,30 +81,30 @@ func Validate_E02(ctx context.Context, opCtx operation.Context, fldPath *field.P
 	return errs
 }
 
-func Validate_E03(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E03) (errs field.ErrorList) {
+func Validate_E03(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E03) (errs field.ErrorList) {
 	// type E03
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "E03, ShortCircuit"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E03, ShortCircuit"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "E03, no flags")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E03, no flags")...)
 
 	return errs
 }
 
-func Validate_EMultiple(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *EMultiple) (errs field.ErrorList) {
+func Validate_EMultiple(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *EMultiple) (errs field.ErrorList) {
 	// type EMultiple
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "EMultiple, ShortCircuit 1"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "EMultiple, ShortCircuit 1"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	if e := validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "EMultiple, ShortCircuit 2"); len(e) != 0 {
+	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "EMultiple, ShortCircuit 2"); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "EMultiple, no flags 1")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "E0, string payload")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "EMultiple, no flags 2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "EMultiple, no flags 1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E0, string payload")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "EMultiple, no flags 2")...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/pointers/zz_generated.validations.go
@@ -37,51 +37,51 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PS")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PS")...)
 			return
 		}(fldPath.Child("ps"), obj.PS, safe.Field(oldObj, func(oldObj *T1) *string { return oldObj.PS }))...)
 
 	// field T1.PI
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PI")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PI")...)
 			return
 		}(fldPath.Child("pi"), obj.PI, safe.Field(oldObj, func(oldObj *T1) *int { return oldObj.PI }))...)
 
 	// field T1.PB
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PB")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PB")...)
 			return
 		}(fldPath.Child("pb"), obj.PB, safe.Field(oldObj, func(oldObj *T1) *bool { return oldObj.PB }))...)
 
 	// field T1.PF
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PF")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PF")...)
 			return
 		}(fldPath.Child("pf"), obj.PF, safe.Field(oldObj, func(oldObj *T1) *float64 { return oldObj.PF }))...)
 
 	// field T1.PT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PT2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PT2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt2"), obj.PT2, safe.Field(oldObj, func(oldObj *T1) *T2 { return oldObj.PT2 }))...)
 
@@ -92,32 +92,32 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// field T2.PS
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PS")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PS")...)
 			return
 		}(fldPath.Child("ps"), obj.PS, safe.Field(oldObj, func(oldObj *T2) *string { return oldObj.PS }))...)
 
 	// field T2.PI
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PI")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PI")...)
 			return
 		}(fldPath.Child("pi"), obj.PI, safe.Field(oldObj, func(oldObj *T2) *int { return oldObj.PI }))...)
 
 	// field T2.PB
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PB")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PB")...)
 			return
 		}(fldPath.Child("pb"), obj.PB, safe.Field(oldObj, func(oldObj *T2) *bool { return oldObj.PB }))...)
 
 	// field T2.PF
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PF")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PF")...)
 			return
 		}(fldPath.Child("pf"), obj.PF, safe.Field(oldObj, func(oldObj *T2) *float64 { return oldObj.PF }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/primitives/zz_generated.validations.go
@@ -37,51 +37,51 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.S }))...)
 
 	// field T1.I
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.I")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.I")...)
 			return
 		}(fldPath.Child("i"), &obj.I, safe.Field(oldObj, func(oldObj *T1) *int { return &oldObj.I }))...)
 
 	// field T1.B
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.B")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.B")...)
 			return
 		}(fldPath.Child("b"), &obj.B, safe.Field(oldObj, func(oldObj *T1) *bool { return &oldObj.B }))...)
 
 	// field T1.F
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.F")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.F")...)
 			return
 		}(fldPath.Child("f"), &obj.F, safe.Field(oldObj, func(oldObj *T1) *float64 { return &oldObj.F }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
@@ -94,39 +94,39 @@ func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Pa
 	// field T1.AnotherT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("anothert2"), &obj.AnotherT2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.AnotherT2 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// field T2.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T2) *string { return &oldObj.S }))...)
 
 	// field T2.I
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.I")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.I")...)
 			return
 		}(fldPath.Child("i"), &obj.I, safe.Field(oldObj, func(oldObj *T2) *int { return &oldObj.I }))...)
 
 	// field T2.B
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.B")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.B")...)
 			return
 		}(fldPath.Child("b"), &obj.B, safe.Field(oldObj, func(oldObj *T2) *bool { return &oldObj.B }))...)
 
 	// field T2.F
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.F")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.F")...)
 			return
 		}(fldPath.Child("f"), &obj.F, safe.Field(oldObj, func(oldObj *T2) *float64 { return &oldObj.F }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/public_private/zz_generated.validations.go
@@ -37,20 +37,20 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.Public
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.Public")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.Public")...)
 			return
 		}(fldPath.Child("public"), &obj.Public, safe.Field(oldObj, func(oldObj *T1) *string { return &oldObj.Public }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/zz_generated.validations.go
@@ -37,98 +37,98 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((E1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((E1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_E1(ctx, opCtx, nil /* fldPath */, obj.(E1), safe.Cast[E1](oldObj))
+			return Validate_E1(ctx, op, nil /* fldPath */, obj.(E1), safe.Cast[E1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T2)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T2)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T2(ctx, opCtx, nil /* fldPath */, obj.(*T2), safe.Cast[*T2](oldObj))
+			return Validate_T2(ctx, op, nil /* fldPath */, obj.(*T2), safe.Cast[*T2](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj E1) (errs field.ErrorList) {
+func Validate_E1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj E1) (errs field.ErrorList) {
 	// type E1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1")...)
-	errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj E1) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1 values")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1")...)
+	errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj E1) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1 values")
 	})...)
-	errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_E1)...)
+	errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_E1)...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// type T1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1")...)
 
 	// field T1.PT1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PT1")...)
-			errs = append(errs, Validate_T1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PT1")...)
+			errs = append(errs, Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt1"), obj.PT1, safe.Field(oldObj, func(oldObj *T1) *T1 { return oldObj.PT1 }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
 	// field T1.PT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PT2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PT2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt2"), obj.PT2, safe.Field(oldObj, func(oldObj *T1) *T2 { return oldObj.PT2 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// type T2
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T2")...)
 
 	// field T2.PT1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PT1")...)
-			errs = append(errs, Validate_T1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PT1")...)
+			errs = append(errs, Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt1"), obj.PT1, safe.Field(oldObj, func(oldObj *T2) *T1 { return oldObj.PT1 }))...)
 
 	// field T2.PT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.PT2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.PT2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt2"), obj.PT2, safe.Field(oldObj, func(oldObj *T2) *T2 { return oldObj.PT2 }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/zz_generated.validations.go
@@ -37,32 +37,32 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct #1")...)
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct #2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct #1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct #2")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField #1")...)
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField #2")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*] #1")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField #1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField #2")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*] #1")
 			})...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*] #2")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*] #2")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.ListField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_map/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_map/deep/zz_generated.validations.go
@@ -37,46 +37,46 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
 				})
 			})...)
 			return
@@ -85,10 +85,10 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
 				})
 			})...)
 			return
@@ -97,20 +97,20 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
 				})
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_MapType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_MapType)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []MapType { return oldObj.ListTypedefField }))...)
 
 	// field Struct.UnvalidatedListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_MapType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_MapType)...)
 			return
 		}(fldPath.Child("UnvalidatedListField"), obj.UnvalidatedListField, safe.Field(oldObj, func(oldObj *Struct) []MapType { return oldObj.UnvalidatedListField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_map/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_map/shallow/zz_generated.validations.go
@@ -37,45 +37,45 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType")...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []map[string]string { return oldObj.ListField }))...)
@@ -83,9 +83,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []map[string]*string { return oldObj.ListPtrField }))...)
@@ -93,18 +93,18 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_MapType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_MapType)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []MapType { return oldObj.ListTypedefField }))...)
 
 	// field Struct.UnvalidatedListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_MapType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_MapType)...)
 			return
 		}(fldPath.Child("UnvalidatedListField"), obj.UnvalidatedListField, safe.Field(oldObj, func(oldObj *Struct) []MapType { return oldObj.UnvalidatedListField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/zz_generated.validations.go
@@ -37,34 +37,34 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.ListField }))...)
@@ -72,9 +72,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []*string { return oldObj.ListPtrField }))...)
@@ -82,22 +82,22 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []StringType { return oldObj.ListTypedefField }))...)
 
 	// field Struct.ListTypedefPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 			return
 		}(fldPath.Child("listTypedefPtrField"), obj.ListTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) []*StringType { return oldObj.ListTypedefPtrField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_slice/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_slice/deep/zz_generated.validations.go
@@ -37,46 +37,46 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_SliceType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
 	// type SliceType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType[*]")
 	})...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
 				})
 			})...)
 			return
@@ -85,10 +85,10 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
 				})
 			})...)
 			return
@@ -97,20 +97,20 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
 				})
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_SliceType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_SliceType)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []SliceType { return oldObj.ListTypedefField }))...)
 
 	// field Struct.UnvalidatedListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_SliceType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_SliceType)...)
 			return
 		}(fldPath.Child("UnvalidatedListField"), obj.UnvalidatedListField, safe.Field(oldObj, func(oldObj *Struct) []SliceType { return oldObj.UnvalidatedListField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_slice/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_slice/shallow/zz_generated.validations.go
@@ -37,45 +37,45 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_SliceType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
 	// type SliceType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type SliceType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType[*]")
 	})...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) [][]string { return oldObj.ListField }))...)
@@ -83,9 +83,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) [][]*string { return oldObj.ListPtrField }))...)
@@ -93,18 +93,18 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_SliceType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_SliceType)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []SliceType { return oldObj.ListTypedefField }))...)
 
 	// field Struct.UnvalidatedListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_SliceType)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_SliceType)...)
 			return
 		}(fldPath.Child("UnvalidatedListField"), obj.UnvalidatedListField, safe.Field(oldObj, func(oldObj *Struct) []SliceType { return oldObj.UnvalidatedListField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/zz_generated.validations.go
@@ -37,83 +37,83 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_OtherStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
+func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
 
 	return errs
 }
 
-func Validate_OtherTypedefStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) (errs field.ErrorList) {
+func Validate_OtherTypedefStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) (errs field.ErrorList) {
 	// type OtherTypedefStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherTypedefStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherTypedefStruct")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []*OtherStruct { return oldObj.ListPtrField }))...)
 
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_OtherTypedefStruct)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_OtherTypedefStruct)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 
 	// field Struct.ListTypedefPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefPtrField[*]")
 			})...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_OtherTypedefStruct)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, Validate_OtherTypedefStruct)...)
 			return
 		}(fldPath.Child("listTypedefPtrField"), obj.ListTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) []*OtherTypedefStruct { return oldObj.ListTypedefPtrField }))...)
 
 	// field Struct.UnvalidatedListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_OtherStruct)...)
 			return
 		}(fldPath.Child("UnvalidatedListField"), obj.UnvalidatedListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.UnvalidatedListField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/zz_generated.validations.go
@@ -37,89 +37,89 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_ListPtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
+func Validate_ListPtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
 	// type ListPtrType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListPtrType")...)
-	errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListPtrType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListPtrType")...)
+	errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListPtrType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_ListType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
+func Validate_ListType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
 	// type ListType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_ListTypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
+func Validate_ListTypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
 	// type ListTypedefType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListTypedefType")...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListTypedefType[*]")
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListTypedefType")...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListTypedefType[*]")
 	})...)
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_StringType)...)
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
-			errs = append(errs, Validate_ListType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) ListType { return oldObj.ListField }))...)
 
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField")...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
-			errs = append(errs, Validate_ListPtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListPtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) ListPtrType { return oldObj.ListPtrField }))...)
 
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField")...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, Validate_ListTypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListTypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) ListTypedefType { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Struct.MapField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Struct.MapField(keys)")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[UnvalidatedStringType]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *UnvalidatedStringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Struct.MapTypedefField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *UnvalidatedStringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Struct.MapTypedefField(keys)")
 			})...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[UnvalidatedStringType]string { return oldObj.MapTypedefField }))...)
@@ -70,18 +70,18 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapValidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[ValidatedStringType]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *ValidatedStringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Struct.MapValidatedTypedefField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ValidatedStringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Struct.MapValidatedTypedefField(keys)")
 			})...)
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, Validate_ValidatedStringType)...)
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, Validate_ValidatedStringType)...)
 			return
 		}(fldPath.Child("mapValidatedTypedefField"), obj.MapValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[ValidatedStringType]string { return oldObj.MapValidatedTypedefField }))...)
 
 	// field Struct.MapTypeField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj UnvalidatedMapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Struct.MapTypeField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Struct.MapTypeField(keys)")
 			})...)
 			return
 		}(fldPath.Child("mapTypeField"), obj.MapTypeField, safe.Field(oldObj, func(oldObj *Struct) UnvalidatedMapType { return oldObj.MapTypeField }))...)
@@ -89,28 +89,28 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ValidatedMapTypeField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "Struct.ValidatedMapTypeField(keys)")
+			errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "Struct.ValidatedMapTypeField(keys)")
 			})...)
-			errs = append(errs, Validate_ValidatedMapType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ValidatedMapType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("validatedMapTypeField"), obj.ValidatedMapTypeField, safe.Field(oldObj, func(oldObj *Struct) ValidatedMapType { return oldObj.ValidatedMapTypeField }))...)
 
 	return errs
 }
 
-func Validate_ValidatedMapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
+func Validate_ValidatedMapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ValidatedMapType) (errs field.ErrorList) {
 	// type ValidatedMapType
-	errs = append(errs, validate.EachMapKey(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "ValidatedMapType(keys)")
+	errs = append(errs, validate.EachMapKey(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "ValidatedMapType(keys)")
 	})...)
 
 	return errs
 }
 
-func Validate_ValidatedStringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *ValidatedStringType) (errs field.ErrorList) {
+func Validate_ValidatedStringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ValidatedStringType) (errs field.ErrorList) {
 	// type ValidatedStringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "ValidatedStringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "ValidatedStringType")...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_map/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_map/deep/zz_generated.validations.go
@@ -37,24 +37,24 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
 				})
 			})...)
 			return
@@ -63,9 +63,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
 				})
 			})...)
 			return
@@ -74,9 +74,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
 				})
 			})...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_map/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_map/shallow/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]map[string]string { return oldObj.MapField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]map[string]*string { return oldObj.MapPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]MapType { return oldObj.MapTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*string { return oldObj.MapPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]StringType { return oldObj.MapTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_slice/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_slice/deep/zz_generated.validations.go
@@ -37,24 +37,24 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*][*]")
 				})
 			})...)
 			return
@@ -63,9 +63,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*][*]")
 				})
 			})...)
 			return
@@ -74,9 +74,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*][*]")
 				})
 			})...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_slice/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_slice/shallow/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string][]string { return oldObj.MapField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string][]*string { return oldObj.MapPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]SliceType { return oldObj.MapTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]OtherStruct { return oldObj.MapField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*OtherStruct { return oldObj.MapPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) map[string]OtherTypedefStruct { return oldObj.MapTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_map/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_map/deep/zz_generated.validations.go
@@ -37,24 +37,24 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
 				})
 			})...)
 			return
@@ -63,9 +63,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
 				})
 			})...)
 			return
@@ -74,9 +74,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
 				})
 			})...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_map/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_map/shallow/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []map[string]string { return oldObj.ListField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []map[string]*string { return oldObj.ListPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []MapType { return oldObj.ListTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.ListField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []*string { return oldObj.ListPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []StringType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []StringType { return oldObj.ListTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_slice/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_slice/deep/zz_generated.validations.go
@@ -37,24 +37,24 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*][*]")
 				})
 			})...)
 			return
@@ -63,9 +63,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*][*]")
 				})
 			})...)
 			return
@@ -74,9 +74,9 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*][*]")
 				})
 			})...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_slice/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_slice/shallow/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) [][]string { return oldObj.ListField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []*string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) [][]*string { return oldObj.ListPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []SliceType { return oldObj.ListTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/zz_generated.validations.go
@@ -37,23 +37,23 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
@@ -61,8 +61,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []*OtherStruct { return oldObj.ListPtrField }))...)
@@ -70,8 +70,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherTypedefStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/zz_generated.validations.go
@@ -37,83 +37,83 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_MapPtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
+func Validate_MapPtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
 	// type MapPtrType
-	errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapPtrType[*]")
+	errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapPtrType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_MapType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
 	// type MapType
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapType[*]")
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_MapTypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
+func Validate_MapTypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
 	// type MapTypedefType
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type MapTypedefType[*]")
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapTypedefType[*]")
 	})...)
-	errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_StringType)...)
+	errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_StringType)...)
 
 	return errs
 }
 
-func Validate_StringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
 	// type StringType
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type StringType")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type Struct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type Struct")...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField[*]")
 			})...)
-			errs = append(errs, Validate_MapType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) MapType { return oldObj.MapField }))...)
 
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapPtrType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapValNilable(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
+			errs = append(errs, validate.EachMapValNilable(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapPtrField[*]")
 			})...)
-			errs = append(errs, Validate_MapPtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapPtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) MapPtrType { return oldObj.MapPtrField }))...)
 
 	// field Struct.MapTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj MapTypedefType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField[*]")
 			})...)
-			errs = append(errs, Validate_MapTypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_MapTypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) MapTypedefType { return oldObj.MapTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/zz_generated.validations.go
@@ -37,72 +37,72 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_ListPtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
+func Validate_ListPtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
 	// type ListPtrType
-	errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListPtrType[*]")
+	errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListPtrType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_ListType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
+func Validate_ListType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
 	// type ListType
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListType[*]")
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_ListTypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
+func Validate_ListTypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
 	// type ListTypedefType
-	errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-		return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type ListTypedefType[*]")
+	errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+		return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type ListTypedefType[*]")
 	})...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListField[*]")
 			})...)
-			errs = append(errs, Validate_ListType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) ListType { return oldObj.ListField }))...)
 
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListPtrType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListPtrField[*]")
 			})...)
-			errs = append(errs, Validate_ListPtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListPtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) ListPtrType { return oldObj.ListPtrField }))...)
 
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj ListTypedefType) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListTypedefField[*]")
 			})...)
-			errs = append(errs, Validate_ListTypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ListTypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) ListTypedefType { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
@@ -38,9 +38,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -49,73 +49,73 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var symbolsForEnum0 = sets.New[Enum0]()
 
-func Validate_Enum0(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
+func Validate_Enum0(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
 	// type Enum0
-	errs = append(errs, validate.Enum(ctx, opCtx, fldPath, obj, oldObj, symbolsForEnum0)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum0)...)
 
 	return errs
 }
 
 var symbolsForEnum1 = sets.New[Enum1](E1V1)
 
-func Validate_Enum1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
+func Validate_Enum1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
 	// type Enum1
-	errs = append(errs, validate.Enum(ctx, opCtx, fldPath, obj, oldObj, symbolsForEnum1)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum1)...)
 
 	return errs
 }
 
 var symbolsForEnum2 = sets.New[Enum2](E2V1, E2V2)
 
-func Validate_Enum2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
+func Validate_Enum2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
 	// type Enum2
-	errs = append(errs, validate.Enum(ctx, opCtx, fldPath, obj, oldObj, symbolsForEnum2)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum2)...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Enum0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum0(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum0(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum0Field"), &obj.Enum0Field, safe.Field(oldObj, func(oldObj *Struct) *Enum0 { return &oldObj.Enum0Field }))...)
 
 	// field Struct.Enum0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum0(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum0(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum0PtrField"), obj.Enum0PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum0 { return oldObj.Enum0PtrField }))...)
 
 	// field Struct.Enum1Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum1Field"), &obj.Enum1Field, safe.Field(oldObj, func(oldObj *Struct) *Enum1 { return &oldObj.Enum1Field }))...)
 
 	// field Struct.Enum1PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum1PtrField"), obj.Enum1PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum1 { return oldObj.Enum1PtrField }))...)
 
 	// field Struct.Enum2Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum2Field"), &obj.Enum2Field, safe.Field(oldObj, func(oldObj *Struct) *Enum2 { return &oldObj.Enum2Field }))...)
 
 	// field Struct.Enum2PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Enum2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("enum2PtrField"), obj.Enum2PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum2 { return oldObj.Enum2PtrField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
@@ -37,93 +37,93 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_OtherStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
+func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.ForbiddenValue(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.ForbiddenValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.OptionalValue(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField")...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 
 	// field Struct.StringPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.ForbiddenPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			if e := validate.ForbiddenPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
-			errs = append(errs, Validate_OtherStruct(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
+			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("otherStructPtrField"), obj.OtherStructPtrField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return oldObj.OtherStructPtrField }))...)
 
 	// field Struct.SliceField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			if e := validate.ForbiddenSlice(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.ForbiddenSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.OptionalSlice(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			if e := validate.ForbiddenMap(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.ForbiddenMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			if e := validate.OptionalMap(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/zz_generated.validations.go
@@ -37,64 +37,64 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_IPStringType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *IPStringType) (errs field.ErrorList) {
+func Validate_IPStringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *IPStringType) (errs field.ErrorList) {
 	// type IPStringType
-	errs = append(errs, validate.IPSloppy(ctx, opCtx, fldPath, obj, oldObj)...)
+	errs = append(errs, validate.IPSloppy(ctx, op, fldPath, obj, oldObj)...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.IPField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.IPSloppy(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.IPSloppy(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ipField"), &obj.IPField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.IPField }))...)
 
 	// field Struct.IPPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.IPSloppy(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.IPSloppy(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ipPtrField"), obj.IPPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.IPPtrField }))...)
 
 	// field Struct.DNSLabelField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.DNSLabel(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.DNSLabel(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("dnsLabelField"), &obj.DNSLabelField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.DNSLabelField }))...)
 
 	// field Struct.DNSLabelPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.DNSLabel(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.DNSLabel(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("dnsLabelPtrField"), obj.DNSLabelPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.DNSLabelPtrField }))...)
 
 	// field Struct.DNSLabelTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
-			errs = append(errs, validate.DNSLabel(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.DNSLabel(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("dnsLabelTypedefField"), &obj.DNSLabelTypedefField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return &oldObj.DNSLabelTypedefField }))...)
 
 	// field Struct.IPTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *IPStringType) (errs field.ErrorList) {
-			errs = append(errs, Validate_IPStringType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_IPStringType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ipTypedefField"), &obj.IPTypedefField, safe.Field(oldObj, func(oldObj *Struct) *IPStringType { return &oldObj.IPTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
@@ -37,106 +37,106 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_ImmutableType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *ImmutableType) (errs field.ErrorList) {
+func Validate_ImmutableType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ImmutableType) (errs field.ErrorList) {
 	// type ImmutableType
-	errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+	errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 
 	// field Struct.StringPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
 
 	// field Struct.StructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("structField"), &obj.StructField, safe.Field(oldObj, func(oldObj *Struct) *ComparableStruct { return &oldObj.StructField }))...)
 
 	// field Struct.StructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("structPtrField"), obj.StructPtrField, safe.Field(oldObj, func(oldObj *Struct) *ComparableStruct { return oldObj.StructPtrField }))...)
 
 	// field Struct.NonComparableStructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *NonComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("noncomparableStructField"), &obj.NonComparableStructField, safe.Field(oldObj, func(oldObj *Struct) *NonComparableStruct { return &oldObj.NonComparableStructField }))...)
 
 	// field Struct.NonComparableStructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *NonComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("noncomparableStructPtrField"), obj.NonComparableStructPtrField, safe.Field(oldObj, func(oldObj *Struct) *NonComparableStruct { return oldObj.NonComparableStructPtrField }))...)
 
 	// field Struct.SliceField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
 	// field Struct.SlicePtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("slicePtrField"), obj.SlicePtrField, safe.Field(oldObj, func(oldObj *Struct) []*string { return oldObj.SlicePtrField }))...)
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 
 	// field Struct.MapPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]*string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapPtrField"), obj.MapPtrField, safe.Field(oldObj, func(oldObj *Struct) map[string]*string { return oldObj.MapPtrField }))...)
 
 	// field Struct.ImmutableField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ImmutableType) (errs field.ErrorList) {
-			errs = append(errs, Validate_ImmutableType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ImmutableType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("immutableField"), &obj.ImmutableField, safe.Field(oldObj, func(oldObj *Struct) *ImmutableType { return &oldObj.ImmutableField }))...)
 
 	// field Struct.ImmutablePtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ImmutableType) (errs field.ErrorList) {
-			errs = append(errs, Validate_ImmutableType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_ImmutableType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("immutablePtrField"), obj.ImmutablePtrField, safe.Field(oldObj, func(oldObj *Struct) *ImmutableType { return oldObj.ImmutablePtrField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.Immutable)...)
 			return
@@ -61,7 +61,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, func(a *OtherStruct, b *OtherStruct) bool {
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, func(a *OtherStruct, b *OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.Immutable)...)
 			return
@@ -70,7 +70,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.Immutable)...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -37,36 +37,36 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
 	// field Struct.ListPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceValNilable(ctx, opCtx, fldPath, obj, oldObj, func(a *OtherStruct, b *OtherStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
+			errs = append(errs, validate.EachSliceValNilable(ctx, op, fldPath, obj, oldObj, func(a *OtherStruct, b *OtherStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
 			return
 		}(fldPath.Child("listPtrField"), obj.ListPtrField, safe.Field(oldObj, func(oldObj *Struct) []*OtherStruct { return oldObj.ListPtrField }))...)
 
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_map/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_map/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -62,7 +62,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -72,7 +72,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -82,7 +82,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []map[string]*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -92,7 +92,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -102,7 +102,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []MapType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -62,7 +62,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -72,7 +72,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -82,7 +82,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -92,7 +92,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []IntType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -102,7 +102,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []IntType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_slice/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -62,7 +62,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -72,7 +72,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -82,7 +82,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj [][]*int) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -92,7 +92,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -102,7 +102,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []SliceType) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -62,7 +62,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -72,7 +72,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -82,7 +82,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []*OtherStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -92,7 +92,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
@@ -102,7 +102,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max10TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/zz_generated.validations.go
@@ -37,18 +37,18 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Max0PtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max0PtrType) (errs field.ErrorList) {
+func Validate_Max0PtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max0PtrType) (errs field.ErrorList) {
 	// type Max0PtrType
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -56,9 +56,9 @@ func Validate_Max0PtrType(ctx context.Context, opCtx operation.Context, fldPath 
 	return errs
 }
 
-func Validate_Max0Type(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max0Type) (errs field.ErrorList) {
+func Validate_Max0Type(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max0Type) (errs field.ErrorList) {
 	// type Max0Type
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -66,9 +66,9 @@ func Validate_Max0Type(ctx context.Context, opCtx operation.Context, fldPath *fi
 	return errs
 }
 
-func Validate_Max0TypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max0TypedefType) (errs field.ErrorList) {
+func Validate_Max0TypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max0TypedefType) (errs field.ErrorList) {
 	// type Max0TypedefType
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 0); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -76,9 +76,9 @@ func Validate_Max0TypedefType(ctx context.Context, opCtx operation.Context, fldP
 	return errs
 }
 
-func Validate_Max10PtrType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max10PtrType) (errs field.ErrorList) {
+func Validate_Max10PtrType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max10PtrType) (errs field.ErrorList) {
 	// type Max10PtrType
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -86,9 +86,9 @@ func Validate_Max10PtrType(ctx context.Context, opCtx operation.Context, fldPath
 	return errs
 }
 
-func Validate_Max10Type(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max10Type) (errs field.ErrorList) {
+func Validate_Max10Type(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max10Type) (errs field.ErrorList) {
 	// type Max10Type
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -96,9 +96,9 @@ func Validate_Max10Type(ctx context.Context, opCtx operation.Context, fldPath *f
 	return errs
 }
 
-func Validate_Max10TypedefType(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj Max10TypedefType) (errs field.ErrorList) {
+func Validate_Max10TypedefType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj Max10TypedefType) (errs field.ErrorList) {
 	// type Max10TypedefType
-	if e := validate.MaxItems(ctx, opCtx, fldPath, obj, oldObj, 10); len(e) != 0 {
+	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10); len(e) != 0 {
 		errs = append(errs, e...)
 		return // do not proceed
 	}
@@ -106,21 +106,21 @@ func Validate_Max10TypedefType(ctx context.Context, opCtx operation.Context, fld
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 	// field Struct.UnvalidatedField has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max0Type) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max0Type(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max0Type(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max0Field"), obj.Max0Field, safe.Field(oldObj, func(oldObj *Struct) Max0Type { return oldObj.Max0Field }))...)
 
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max10Type) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max10Type(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max10Type(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max10Field"), obj.Max10Field, safe.Field(oldObj, func(oldObj *Struct) Max10Type { return oldObj.Max10Field }))...)
 
@@ -129,28 +129,28 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.Max0PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max0PtrType) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max0PtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max0PtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max0PtrField"), obj.Max0PtrField, safe.Field(oldObj, func(oldObj *Struct) Max0PtrType { return oldObj.Max0PtrField }))...)
 
 	// field Struct.Max10PtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max10PtrType) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max10PtrType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max10PtrType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max10PtrField"), obj.Max10PtrField, safe.Field(oldObj, func(oldObj *Struct) Max10PtrType { return oldObj.Max10PtrField }))...)
 
 	// field Struct.Max0TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max0TypedefType) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max0TypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max0TypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max0TypedefField"), obj.Max0TypedefField, safe.Field(oldObj, func(oldObj *Struct) Max0TypedefType { return oldObj.Max0TypedefField }))...)
 
 	// field Struct.Max10TypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj Max10TypedefType) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max10TypedefType(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max10TypedefType(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max10TypedefField"), obj.Max10TypedefField, safe.Field(oldObj, func(oldObj *Struct) Max10TypedefType { return oldObj.Max10TypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/zz_generated.validations.go
@@ -37,71 +37,71 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Max0Type(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Max0Type) (errs field.ErrorList) {
+func Validate_Max0Type(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Max0Type) (errs field.ErrorList) {
 	// type Max0Type
-	errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 0)...)
+	errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 0)...)
 
 	return errs
 }
 
-func Validate_Max10Type(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Max10Type) (errs field.ErrorList) {
+func Validate_Max10Type(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Max10Type) (errs field.ErrorList) {
 	// type Max10Type
-	errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 10)...)
+	errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.Max0Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 0)...)
 			return
 		}(fldPath.Child("max0Field"), &obj.Max0Field, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.Max0Field }))...)
 
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 10)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
 			return
 		}(fldPath.Child("max10Field"), &obj.Max10Field, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.Max10Field }))...)
 
 	// field Struct.Max0UnvalidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
-			errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 0)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 0)...)
 			return
 		}(fldPath.Child("max0UnvalidatedTypedefField"), &obj.Max0UnvalidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return &oldObj.Max0UnvalidatedTypedefField }))...)
 
 	// field Struct.Max10UnvalidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
-			errs = append(errs, validate.MaxLength(ctx, opCtx, fldPath, obj, oldObj, 10)...)
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
 			return
 		}(fldPath.Child("max10UnvalidatedTypedefField"), &obj.Max10UnvalidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return &oldObj.Max10UnvalidatedTypedefField }))...)
 
 	// field Struct.Max0ValidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Max0Type) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max0Type(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max0Type(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max0ValidatedTypedefField"), &obj.Max0ValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *Max0Type { return &oldObj.Max0ValidatedTypedefField }))...)
 
 	// field Struct.Max10ValidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Max10Type) (errs field.ErrorList) {
-			errs = append(errs, Validate_Max10Type(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_Max10Type(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max10ValidatedTypedefField"), &obj.Max10ValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *Max10Type { return &oldObj.Max10ValidatedTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
@@ -37,82 +37,82 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_OtherStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
+func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.OptionalValue(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField")...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 
 	// field Struct.StringPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
 
 	// field Struct.OtherStructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.OtherStructField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructField")...)
 			// optional non-pointer structs are purely documentation
-			errs = append(errs, Validate_OtherStruct(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("otherStructField"), &obj.OtherStructField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return &oldObj.OtherStructField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
-			errs = append(errs, Validate_OtherStruct(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
+			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("otherStructPtrField"), obj.OtherStructPtrField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return oldObj.OtherStructPtrField }))...)
 
 	// field Struct.SliceField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			if e := validate.OptionalSlice(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			if e := validate.OptionalMap(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/zz_generated.validations.go
@@ -37,24 +37,24 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.XEnabledField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, func() field.ErrorList {
-				if opCtx.Options.Has("FeatureX") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.XEnabledField")
+				if op.Options.Has("FeatureX") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.XEnabledField")
 				} else {
 					return nil // skip validation
 				}
@@ -66,8 +66,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, func() field.ErrorList {
-				if !opCtx.Options.Has("FeatureX") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.XDisabledField")
+				if !op.Options.Has("FeatureX") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.XDisabledField")
 				} else {
 					return nil // skip validation
 				}
@@ -79,8 +79,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, func() field.ErrorList {
-				if opCtx.Options.Has("FeatureY") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.YEnabledField")
+				if op.Options.Has("FeatureY") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.YEnabledField")
 				} else {
 					return nil // skip validation
 				}
@@ -92,8 +92,8 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, func() field.ErrorList {
-				if !opCtx.Options.Has("FeatureY") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.YDisabledField")
+				if !op.Options.Has("FeatureY") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.YDisabledField")
 				} else {
 					return nil // skip validation
 				}
@@ -105,15 +105,15 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, func() field.ErrorList {
-				if !opCtx.Options.Has("FeatureY") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.XYMixedField/Y")
+				if !op.Options.Has("FeatureY") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.XYMixedField/Y")
 				} else {
 					return nil // skip validation
 				}
 			}()...)
 			errs = append(errs, func() field.ErrorList {
-				if opCtx.Options.Has("FeatureX") {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.XYMixedField/X")
+				if op.Options.Has("FeatureX") {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.XYMixedField/X")
 				} else {
 					return nil // skip validation
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
@@ -37,87 +37,87 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_OtherStruct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
+func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type OtherStruct")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
 
 	return errs
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.RequiredValue(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField")...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 
 	// field Struct.StringPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			if e := validate.RequiredPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
 
 	// field Struct.OtherStructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.OtherStructField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructField")...)
 			// required non-pointer structs are purely documentation
-			errs = append(errs, Validate_OtherStruct(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("otherStructField"), &obj.OtherStructField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return &oldObj.OtherStructField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			if e := validate.RequiredPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
-			errs = append(errs, Validate_OtherStruct(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField")...)
+			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("otherStructPtrField"), obj.OtherStructPtrField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return oldObj.OtherStructPtrField }))...)
 
 	// field Struct.SliceField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			if e := validate.RequiredSlice(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceField")...)
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			if e := validate.RequiredMap(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 				return // do not proceed
 			}
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.MapField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/zz_generated.validations.go
@@ -37,37 +37,37 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-				return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructField.StructField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+				return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructField.StructField")
 				})
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []SmallStruct { return o.SliceField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-					return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-						return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructField.SliceField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []SmallStruct { return o.SliceField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+					return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+						return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructField.SliceField")
 					})
 				})
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-					return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-						return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructField.MapField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+					return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+						return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructField.MapField")
 					})
 				})
 			})...)
@@ -77,22 +77,22 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.StructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-				return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-					return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructPtrField.StructField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+				return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructPtrField.StructField")
 				})
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []SmallStruct { return o.SliceField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
-				return validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-					return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-						return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructPtrField.SliceField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []SmallStruct { return o.SliceField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
+				return validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+					return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+						return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructPtrField.SliceField")
 					})
 				})
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {
-				return validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-					return validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-						return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "StructPtrField.MapField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {
+				return validate.EachMapVal(ctx, op, fldPath, obj, oldObj, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+					return validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *SmallStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+						return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "StructPtrField.MapField")
 					})
 				})
 			})...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/zz_generated.validations.go
@@ -38,21 +38,21 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.StructType
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *other.StructType) (errs field.ErrorList) {
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *other.StructType) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.(other.StructType).StringField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *other.StructType) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.(other.StructType).StringField")
 			})...)
 			// NOTE: Not validating this field's type: other.StructType is in a non-included package.
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/zz_generated.validations.go
@@ -37,35 +37,35 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *OtherStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructField.StringField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *OtherStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructField.StringField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "pointerField", func(o *OtherStruct) *string { return o.PointerField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructField.PointerField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "pointerField", func(o *OtherStruct) *string { return o.PointerField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructField.PointerField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructField.StructField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructField.StructField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []string { return o.SliceField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructField.SliceField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []string { return o.SliceField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructField.SliceField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]string { return o.MapField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructField.MapField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]string { return o.MapField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructField.MapField")
 			})...)
 			return
 		}(fldPath.Child("structField"), &obj.StructField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return &oldObj.StructField }))...)
@@ -73,20 +73,20 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.StructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "stringField", func(o *OtherStruct) *string { return &o.StringField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.StringField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField", func(o *OtherStruct) *string { return &o.StringField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.StringField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "pointerField", func(o *OtherStruct) *string { return o.PointerField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.PointerField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "pointerField", func(o *OtherStruct) *string { return o.PointerField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.PointerField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.StructField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField", func(o *OtherStruct) *SmallStruct { return &o.StructField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.StructField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []string { return o.SliceField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.SliceField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField", func(o *OtherStruct) []string { return o.SliceField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.SliceField")
 			})...)
-			errs = append(errs, validate.Subfield(ctx, opCtx, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]string { return o.MapField }, func(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
-				return validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.MapField")
+			errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField", func(o *OtherStruct) map[string]string { return o.MapField }, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
+				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "subfield Struct.StructPtrField.MapField")
 			})...)
 			return
 		}(fldPath.Child("structPtrField"), obj.StructPtrField, safe.Field(oldObj, func(oldObj *Struct) *OtherStruct { return oldObj.StructPtrField }))...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -48,9 +48,9 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var unionMembershipForStruct = validate.NewDiscriminatedUnionMembership("d", [2]string{"m1", "CustomM1"}, [2]string{"m2", "CustomM2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.DiscriminatedUnion(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation
@@ -58,7 +58,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -67,7 +67,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -48,9 +48,9 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var unionMembershipForStruct = validate.NewDiscriminatedUnionMembership("d")
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.DiscriminatedUnion(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStruct, obj.D)...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -49,10 +49,10 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 var unionMembershipForStructunion1 = validate.NewDiscriminatedUnionMembership("d1", [2]string{"u1m1", "U1M1"}, [2]string{"u1m2", "U1M2"})
 var unionMembershipForStructunion2 = validate.NewDiscriminatedUnionMembership("d2", [2]string{"u2m1", "U2M1"}, [2]string{"u2m2", "U2M2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.DiscriminatedUnion(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.D1, obj.U1M1, obj.U1M2)...)
-	errs = append(errs, validate.DiscriminatedUnion(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.D2, obj.U2M1, obj.U2M2)...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.D1, obj.U1M1, obj.U1M2)...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.D2, obj.U2M1, obj.U2M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D1 has no validation
@@ -60,7 +60,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U1M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -69,7 +69,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U1M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -80,7 +80,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U2M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -89,7 +89,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U2M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -48,9 +48,9 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var unionMembershipForStruct = validate.NewDiscriminatedUnionMembership("d", [2]string{"m1", "M1"}, [2]string{"m2", "M2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.DiscriminatedUnion(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation
@@ -58,7 +58,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -67,7 +67,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -48,9 +48,9 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var unionMembershipForStruct = validate.NewUnionMembership([2]string{"m1", "CustomM1"}, [2]string{"m2", "CustomM2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.Union(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation
@@ -58,7 +58,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -67,7 +67,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -49,10 +49,10 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 var unionMembershipForStructunion1 = validate.NewUnionMembership([2]string{"u1m1", "U1M1"}, [2]string{"u1m2", "U1M2"})
 var unionMembershipForStructunion2 = validate.NewUnionMembership([2]string{"u2m1", "U2M1"}, [2]string{"u2m2", "U2M2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.Union(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.U1M1, obj.U1M2)...)
-	errs = append(errs, validate.Union(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.U2M1, obj.U2M2)...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.U1M1, obj.U1M2)...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.U2M1, obj.U2M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation
@@ -60,7 +60,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U1M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -69,7 +69,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U1M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -78,7 +78,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U2M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -87,7 +87,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.U2M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
@@ -37,9 +37,9 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
@@ -48,9 +48,9 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 var unionMembershipForStruct = validate.NewUnionMembership([2]string{"m1", "M1"}, [2]string{"m2", "M2"})
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// type Struct
-	errs = append(errs, validate.Union(ctx, opCtx, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation
@@ -58,7 +58,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return
@@ -67,7 +67,7 @@ func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *fiel
 	// field Struct.M2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *M2) (errs field.ErrorList) {
-			if e := validate.OptionalPointer(ctx, opCtx, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				return // do not proceed
 			}
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_false/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_false/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field Struct.StringField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField")...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_true/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/validate_true/zz_generated.validations.go
@@ -37,22 +37,22 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, true, "field Struct.StringField")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field Struct.StringField")...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
@@ -38,68 +38,68 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
+func Validate_E1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
 	// type E1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1")...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.TypeMeta has no validation
 
 	// field T1.S1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *primitives.T1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, opCtx, fldPath, obj, oldObj, false, "T1.S1")...)
-			errs = append(errs, primitives.Validate_T1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, op, fldPath, obj, oldObj, false, "T1.S1")...)
+			errs = append(errs, primitives.Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("s1"), obj.S1, safe.Field(oldObj, func(oldObj *T1) *primitives.T1 { return oldObj.S1 }))...)
 
 	// field T1.PS1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *primitives.T1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, opCtx, fldPath, obj, oldObj, false, "PT1.PS1")...)
-			errs = append(errs, primitives.Validate_T1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, op, fldPath, obj, oldObj, false, "PT1.PS1")...)
+			errs = append(errs, primitives.Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ps1"), obj.PS1, safe.Field(oldObj, func(oldObj *T1) *primitives.T1 { return oldObj.PS1 }))...)
 
 	// field T1.E1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*E1](ctx, opCtx, fldPath, obj, oldObj, false, "T1.E1")...)
-			errs = append(errs, Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult[*E1](ctx, op, fldPath, obj, oldObj, false, "T1.E1")...)
+			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e1"), &obj.E1, safe.Field(oldObj, func(oldObj *T1) *E1 { return &oldObj.E1 }))...)
 
 	// field T1.PE1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*E1](ctx, opCtx, fldPath, obj, oldObj, true, "T1.PE1")...)
-			errs = append(errs, Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult[*E1](ctx, op, fldPath, obj, oldObj, true, "T1.PE1")...)
+			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pe1"), obj.PE1, safe.Field(oldObj, func(oldObj *T1) *E1 { return oldObj.PE1 }))...)
 
 	// field T1.I1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*int](ctx, opCtx, fldPath, obj, oldObj, false, "T1.I1")...)
+			errs = append(errs, validate.FixedResult[*int](ctx, op, fldPath, obj, oldObj, false, "T1.I1")...)
 			return
 		}(fldPath.Child("i1"), &obj.I1, safe.Field(oldObj, func(oldObj *T1) *int { return &oldObj.I1 }))...)
 
 	// field T1.PI1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult[*int](ctx, opCtx, fldPath, obj, oldObj, true, "T1.PI1")...)
+			errs = append(errs, validate.FixedResult[*int](ctx, op, fldPath, obj, oldObj, true, "T1.PI1")...)
 			return
 		}(fldPath.Child("pi1"), obj.PI1, safe.Field(oldObj, func(oldObj *T1) *int { return oldObj.PI1 }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/typedefs/zz_generated.validations.go
@@ -37,147 +37,147 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_E1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
+func Validate_E1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
 	// type E1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E1")...)
 
 	return errs
 }
 
-func Validate_E2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E2) (errs field.ErrorList) {
+func Validate_E2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E2) (errs field.ErrorList) {
 	// type E2
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E2")...)
 
 	return errs
 }
 
-func Validate_E3(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E3) (errs field.ErrorList) {
+func Validate_E3(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E3) (errs field.ErrorList) {
 	// type E3
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E3")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E3")...)
 
 	return errs
 }
 
-func Validate_E4(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *E4) (errs field.ErrorList) {
+func Validate_E4(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *E4) (errs field.ErrorList) {
 	// type E4
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type E4")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type E4")...)
 
 	// field E4.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *E4) *string { return &oldObj.S }))...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// type T1
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T1")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T1")...)
 
 	// field T1.TypeMeta has no validation
 
 	// field T1.E1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E1")...)
-			errs = append(errs, Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E1")...)
+			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e1"), &obj.E1, safe.Field(oldObj, func(oldObj *T1) *E1 { return &oldObj.E1 }))...)
 
 	// field T1.PE1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E1) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PE1")...)
-			errs = append(errs, Validate_E1(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PE1")...)
+			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pe1"), obj.PE1, safe.Field(oldObj, func(oldObj *T1) *E1 { return oldObj.PE1 }))...)
 
 	// field T1.E2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E2")...)
-			errs = append(errs, Validate_E2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E2")...)
+			errs = append(errs, Validate_E2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e2"), &obj.E2, safe.Field(oldObj, func(oldObj *T1) *E2 { return &oldObj.E2 }))...)
 
 	// field T1.PE2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PE2")...)
-			errs = append(errs, Validate_E2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PE2")...)
+			errs = append(errs, Validate_E2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pe2"), obj.PE2, safe.Field(oldObj, func(oldObj *T1) *E2 { return oldObj.PE2 }))...)
 
 	// field T1.E3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E3")...)
-			errs = append(errs, Validate_E3(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E3")...)
+			errs = append(errs, Validate_E3(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e3"), &obj.E3, safe.Field(oldObj, func(oldObj *T1) *E3 { return &oldObj.E3 }))...)
 
 	// field T1.PE3
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E3) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PE3")...)
-			errs = append(errs, Validate_E3(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PE3")...)
+			errs = append(errs, Validate_E3(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pe3"), obj.PE3, safe.Field(oldObj, func(oldObj *T1) *E3 { return oldObj.PE3 }))...)
 
 	// field T1.E4
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E4) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.E4")...)
-			errs = append(errs, Validate_E4(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.E4")...)
+			errs = append(errs, Validate_E4(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("e4"), &obj.E4, safe.Field(oldObj, func(oldObj *T1) *E4 { return &oldObj.E4 }))...)
 
 	// field T1.PE4
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *E4) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PE4")...)
-			errs = append(errs, Validate_E4(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PE4")...)
+			errs = append(errs, Validate_E4(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pe4"), obj.PE4, safe.Field(oldObj, func(oldObj *T1) *E4 { return oldObj.PE4 }))...)
 
 	// field T1.T2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.T2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.T2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("t2"), &obj.T2, safe.Field(oldObj, func(oldObj *T1) *T2 { return &oldObj.T2 }))...)
 
 	// field T1.PT2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T1.PT2")...)
-			errs = append(errs, Validate_T2(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T1.PT2")...)
+			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("pt2"), obj.PT2, safe.Field(oldObj, func(oldObj *T1) *T2 { return oldObj.PT2 }))...)
 
 	return errs
 }
 
-func Validate_T2(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
+func Validate_T2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T2) (errs field.ErrorList) {
 	// type T2
-	errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "type T2")...)
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T2")...)
 
 	// field T2.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "field T2.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T2.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *T2) *string { return &oldObj.S }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/lists/zz_generated.validations.go
@@ -37,37 +37,37 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*M1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*M1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_M1(ctx, opCtx, nil /* fldPath */, obj.(*M1), safe.Cast[*M1](oldObj))
+			return Validate_M1(ctx, op, nil /* fldPath */, obj.(*M1), safe.Cast[*M1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_M1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
+func Validate_M1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
 	// field M1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "M1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "M1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *M1) *string { return &oldObj.S }))...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.LM1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []M1) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, opCtx, fldPath, obj, oldObj, nil, Validate_M1)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, Validate_M1)...)
 			return
 		}(fldPath.Child("lm1"), obj.LM1, safe.Field(oldObj, func(oldObj *T1) []M1 { return oldObj.LM1 }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/maps/zz_generated.validations.go
@@ -37,37 +37,37 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*M1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*M1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_M1(ctx, opCtx, nil /* fldPath */, obj.(*M1), safe.Cast[*M1](oldObj))
+			return Validate_M1(ctx, op, nil /* fldPath */, obj.(*M1), safe.Cast[*M1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
-	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*T1)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_T1(ctx, opCtx, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
+			return Validate_T1(ctx, op, nil /* fldPath */, obj.(*T1), safe.Cast[*T1](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_M1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
+func Validate_M1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *M1) (errs field.ErrorList) {
 	// field M1.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.FixedResult(ctx, opCtx, fldPath, obj, oldObj, false, "M1.S")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "M1.S")...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *M1) *string { return &oldObj.S }))...)
 
 	return errs
 }
 
-func Validate_T1(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
+func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *T1) (errs field.ErrorList) {
 	// field T1.MSM1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]M1) (errs field.ErrorList) {
-			errs = append(errs, validate.EachMapVal(ctx, opCtx, fldPath, obj, oldObj, Validate_M1)...)
+			errs = append(errs, validate.EachMapVal(ctx, op, fldPath, obj, oldObj, Validate_M1)...)
 			return
 		}(fldPath.Child("msm1"), obj.MSM1, safe.Field(oldObj, func(oldObj *T1) map[string]M1 { return oldObj.MSM1 }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
@@ -37,41 +37,41 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.SP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("sp"), obj.SP, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.SP }))...)
 
 	// field Struct.IP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ip"), obj.IP, safe.Field(oldObj, func(oldObj *Struct) *int { return oldObj.IP }))...)
 
 	// field Struct.BP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("bp"), obj.BP, safe.Field(oldObj, func(oldObj *Struct) *bool { return oldObj.BP }))...)
 
 	// field Struct.FP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("fp"), obj.FP, safe.Field(oldObj, func(oldObj *Struct) *float64 { return oldObj.FP }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
@@ -37,41 +37,41 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, opCtx operation.Context, obj, oldObj interface{}, subresources ...string) field.ErrorList {
+	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}, subresources ...string) field.ErrorList {
 		if len(subresources) == 0 {
-			return Validate_Struct(ctx, opCtx, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
+			return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresources: %v", obj, subresources))}
 	})
 	return nil
 }
 
-func Validate_Struct(ctx context.Context, opCtx operation.Context, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
+func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.S }))...)
 
 	// field Struct.I
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("i"), &obj.I, safe.Field(oldObj, func(oldObj *Struct) *int { return &oldObj.I }))...)
 
 	// field Struct.B
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("b"), &obj.B, safe.Field(oldObj, func(oldObj *Struct) *bool { return &oldObj.B }))...)
 
 	// field Struct.F
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, opCtx, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("f"), &obj.F, safe.Field(oldObj, func(oldObj *Struct) *float64 { return &oldObj.F }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/testscheme/testscheme.go
@@ -47,18 +47,18 @@ import (
 // to also be used as a scheme builder.
 // Must only be used with tests that perform all registration before calls to validate.
 type Scheme struct {
-	validationFuncs    map[reflect.Type]func(ctx context.Context, opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList
+	validationFuncs    map[reflect.Type]func(ctx context.Context, op operation.Operation, object, oldObject interface{}, subresources ...string) field.ErrorList
 	registrationErrors field.ErrorList
 }
 
 // New creates a new Scheme.
 func New() *Scheme {
-	return &Scheme{validationFuncs: map[reflect.Type]func(ctx context.Context, opCtx operation.Context, object interface{}, oldObject interface{}, subresources ...string) field.ErrorList{}}
+	return &Scheme{validationFuncs: map[reflect.Type]func(ctx context.Context, op operation.Operation, object interface{}, oldObject interface{}, subresources ...string) field.ErrorList{}}
 }
 
 // AddValidationFunc registers a validation function.
 // Last writer wins.
-func (s *Scheme) AddValidationFunc(srcType any, fn func(ctx context.Context, opCtx operation.Context, object, oldObject interface{}, subresources ...string) field.ErrorList) {
+func (s *Scheme) AddValidationFunc(srcType any, fn func(ctx context.Context, op operation.Operation, object, oldObject interface{}, subresources ...string) field.ErrorList) {
 	s.validationFuncs[reflect.TypeOf(srcType)] = fn
 }
 
@@ -68,7 +68,7 @@ func (s *Scheme) Validate(ctx context.Context, opts sets.Set[string], object any
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(ctx, operation.Context{Operation: operation.Create, Options: opts}, object, nil, subresources...)
+		return fn(ctx, operation.Operation{Type: operation.Create, Options: opts}, object, nil, subresources...)
 	}
 	return nil
 }
@@ -79,7 +79,7 @@ func (s *Scheme) ValidateUpdate(ctx context.Context, opts sets.Set[string], obje
 		return s.registrationErrors // short circuit with registration errors if any are present
 	}
 	if fn, ok := s.validationFuncs[reflect.TypeOf(object)]; ok {
-		return fn(ctx, operation.Context{Operation: operation.Update}, object, oldObject, subresources...)
+		return fn(ctx, operation.Operation{Type: operation.Update}, object, oldObject, subresources...)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -272,7 +272,7 @@ type FunctionGen interface {
 	// invocation is generated.
 	//
 	// The function signature must be of the form:
-	//   func(opCtx operation.Context,
+	//   func(op operation.Operation,
 	//        fldPath field.Path,
 	//        value, oldValue <ValueType>,     // always nilable
 	//        extraArgs[0] <extraArgs[0]Type>, // optional
@@ -411,7 +411,7 @@ func (v variableGen) Init() FunctionGen {
 }
 
 // WrapperFunction describes a function literal which has the fingerprint of a
-// regular validation function (opCtx, fldPath, obj, oldObj) and calls another
+// regular validation function (op, fldPath, obj, oldObj) and calls another
 // validation function with the same signature, plus extra args if needed.
 type WrapperFunction struct {
 	Function FunctionGen


### PR DESCRIPTION
Builds on context.Context PR.

I could be talked into "Operation" -> "Op" but it feels parallel to "Context" like this.

I don't love "Code" - ideas?

Fixes https://github.com/jpbetz/kubernetes/issues/101