### PR TITLE
Validation gen fix tests revert msg changes

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/dns_test.go
@@ -22,206 +22,66 @@ import (
 )
 
 func TestIsDNS1123Label(t *testing.T) {
-	// errors expected
-	const minSizeError = "must contain at least 1 character"
-	const maxSizeError = "must be no more than 63 characters"
-	const startEndError = "must start and end with lower-case alphanumeric characters"
-	const interiorError = "must contain only lower-case alphanumeric characters or '-'"
-
-	cases := []struct {
-		input  string
-		expect []string // regexes
-	}{
-		// Good values
-		{"a", nil},
-		{"ab", nil},
-		{"abc", nil},
-		{"a1", nil},
-		{"a-1", nil},
-		{"a--1--2--b", nil},
-		{"0", nil},
-		{"01", nil},
-		{"012", nil},
-		{"1a", nil},
-		{"1-a", nil},
-		{"1--a--b--2", nil},
-		{strings.Repeat("a", 63), nil},
-
-		// Bad values
-		{"", mkMsgs(minSizeError)},
-		{"A", mkMsgs(startEndError)},
-		{"ABC", mkMsgs(startEndError, interiorError)},
-		{"aBc", mkMsgs(interiorError)},
-		{"AbC", mkMsgs(startEndError)},
-		{"A1", mkMsgs(startEndError)},
-		{"A-1", mkMsgs(startEndError)},
-		{"1-A", mkMsgs(startEndError)},
-		{"-", mkMsgs(startEndError)},
-		{"a-", mkMsgs(startEndError)},
-		{"-a", mkMsgs(startEndError)},
-		{"1-", mkMsgs(startEndError)},
-		{"-1", mkMsgs(startEndError)},
-		{"_", mkMsgs(startEndError)},
-		{"a_", mkMsgs(startEndError)},
-		{"_a", mkMsgs(startEndError)},
-		{"a_b", mkMsgs(interiorError)},
-		{"1_", mkMsgs(startEndError)},
-		{"_1", mkMsgs(startEndError)},
-		{"1_2", mkMsgs(interiorError)},
-		{".", mkMsgs(startEndError)},
-		{"a.", mkMsgs(startEndError)},
-		{".a", mkMsgs(startEndError)},
-		{"a.b", mkMsgs(interiorError)},
-		{"1.", mkMsgs(startEndError)},
-		{".1", mkMsgs(startEndError)},
-		{"1.2", mkMsgs(interiorError)},
-		{" ", mkMsgs(startEndError)},
-		{"a ", mkMsgs(startEndError)},
-		{" a", mkMsgs(startEndError)},
-		{"a b", mkMsgs(interiorError)},
-		{"1 ", mkMsgs(startEndError)},
-		{" 1", mkMsgs(startEndError)},
-		{"1 2", mkMsgs(interiorError)},
-		{strings.Repeat("a", 64), mkMsgs(maxSizeError)},
-		{strings.Repeat("-", 64), mkMsgs(maxSizeError)},
-		{strings.Repeat(".", 64), mkMsgs(maxSizeError)},
-		{strings.Repeat("aBc", 64), mkMsgs(maxSizeError)},
-		{strings.Repeat("AbC", 64), mkMsgs(maxSizeError)},
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		strings.Repeat("a", 63),
+	}
+	for _, val := range goodValues {
+		if msgs := IsDNS1123Label(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
 	}
 
-	for i, tc := range cases {
-		result := IsDNS1123Label(tc.input)
-		testVerify(t, i, tc.input, tc.expect, result)
+	badValues := []string{
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		strings.Repeat("a", 64),
+	}
+	for _, val := range badValues {
+		if msgs := IsDNS1123Label(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
 	}
 }
 
 func TestIsDNS1123Subdomain(t *testing.T) {
-	// errors expected
-	const minSizeError = "must contain at least 1 character"
-	const partMinSizeError = "each part must contain at least 1 character"
-	const maxSizeError = "must be no more than 253 characters"
-	const startEndError = "must start and end with lower-case alphanumeric characters"
-	const partStartEndError = "each part must start and end with lower-case alphanumeric characters"
-	const partInteriorError = "each part must contain only lower-case alphanumeric characters or '-'"
-
-	cases := []struct {
-		input  string
-		expect []string // regexes
-	}{
-		// Good values
-		{"a", nil},
-		{"ab", nil},
-		{"abc", nil},
-		{"a1", nil},
-		{"a-1", nil},
-		{"a--1--2--b", nil},
-		{"0", nil},
-		{"01", nil},
-		{"012", nil},
-		{"1a", nil},
-		{"1-a", nil},
-		{"1--a--b--2", nil},
-		{strings.Repeat("a", 63), nil},
-		{strings.Repeat("a", 64), nil},  // allowed for backwards compat
-		{strings.Repeat("a", 253), nil}, // allowed for backwards compat
-		{"a.a", nil},
-		{"ab.a", nil},
-		{"abc.a", nil},
-		{"a1.a", nil},
-		{"a-1.a", nil},
-		{"a--1--2--b.a", nil},
-		{"0.a", nil},
-		{"01.a", nil},
-		{"012.a", nil},
-		{"1a.a", nil},
-		{"1-a.a", nil},
-		{"1--a--b--2.a", nil},
-		{strings.Repeat("a", 63) + ".a", nil},
-		{strings.Repeat("a", 64) + ".a", nil},  // allowed for backwards compat
-		{strings.Repeat("a", 251) + ".a", nil}, // allowed for backwards compat
-		{"a.1", nil},
-		{"ab.1", nil},
-		{"abc.1", nil},
-		{"a1.1", nil},
-		{"a-1.1", nil},
-		{"a--1--2--b.1", nil},
-		{"0.1", nil},
-		{"01.1", nil},
-		{"012.1", nil},
-		{"1a.1", nil},
-		{"1-a.1", nil},
-		{"1--a--b--2.1", nil},
-		{strings.Repeat("a", 63) + ".1", nil},
-		{strings.Repeat("a", 64) + ".1", nil},  // allowed for backwards compat
-		{strings.Repeat("a", 251) + ".1", nil}, // allowed for backwards compat
-		{"a.b.c.d.e", nil},
-		{"aa.bb.cc.dd.ee", nil},
-		{"1.2.3.4.5", nil},
-		{"11.22.33.44.55", nil},
-		{strings.Repeat("a", 126) + "." + strings.Repeat("b", 126), nil},
-		{strings.Repeat("0", 126) + "." + strings.Repeat("1", 126), nil},
-		{strings.Repeat("0.", 126) + "0", nil},
-
-		// Bad values
-		{"", mkMsgs(minSizeError)},
-		{"A", mkMsgs(startEndError)},
-		{"ABC", mkMsgs(startEndError, partInteriorError)},
-		{"aBc", mkMsgs(partInteriorError)},
-		{"AbC", mkMsgs(startEndError)},
-		{"A1", mkMsgs(startEndError)},
-		{"A-1", mkMsgs(startEndError)},
-		{"1-A", mkMsgs(startEndError)},
-		{"-", mkMsgs(startEndError)},
-		{"a-", mkMsgs(startEndError)},
-		{"-a", mkMsgs(startEndError)},
-		{"1-", mkMsgs(startEndError)},
-		{"-1", mkMsgs(startEndError)},
-		{"_", mkMsgs(startEndError)},
-		{"a_", mkMsgs(startEndError)},
-		{"_a", mkMsgs(startEndError)},
-		{"a_b", mkMsgs(partInteriorError)},
-		{"1_", mkMsgs(startEndError)},
-		{"_1", mkMsgs(startEndError)},
-		{"1_2", mkMsgs(partInteriorError)},
-		{".", mkMsgs(startEndError)},
-		{"a.", mkMsgs(startEndError)},
-		{".a", mkMsgs(startEndError)},
-		{"1.", mkMsgs(startEndError)},
-		{".1", mkMsgs(startEndError)},
-		{"a..b", mkMsgs(partMinSizeError)},
-		{"0..1", mkMsgs(partMinSizeError)},
-		{" ", mkMsgs(startEndError)},
-		{"a ", mkMsgs(startEndError)},
-		{" a", mkMsgs(startEndError)},
-		{"a b", mkMsgs(partInteriorError)},
-		{"1 ", mkMsgs(startEndError)},
-		{" 1", mkMsgs(startEndError)},
-		{"1 2", mkMsgs(partInteriorError)},
-		{"A.b", mkMsgs(startEndError)},
-		{"aB.b", mkMsgs(partStartEndError)},
-		{"ab.A", mkMsgs(startEndError)},
-		{"A.0", mkMsgs(startEndError)},
-		{"0B.0", mkMsgs(partStartEndError)},
-		{"00.A", mkMsgs(startEndError)},
-		{"A.B.C.D.E", mkMsgs(startEndError)},
-		{"AA.BB.CC.DD.EE", mkMsgs(startEndError)},
-		{"a.B.c.d.e", mkMsgs(startEndError)},
-		{"aa.bB.cc.dd.ee", mkMsgs(startEndError)},
-		{"a@b", mkMsgs(partInteriorError)},
-		{"a,b", mkMsgs(partInteriorError)},
-		{"a_b", mkMsgs(partInteriorError)},
-		{"a;b", mkMsgs(partInteriorError)},
-		{"a:b", mkMsgs(partInteriorError)},
-		{`a%b`, mkMsgs(partInteriorError)},
-		{"a?b", mkMsgs(partInteriorError)},
-		{"a$b", mkMsgs(partInteriorError)},
-		{strings.Repeat("a", 254), mkMsgs(maxSizeError)},
-		{strings.Repeat("-", 254), mkMsgs(maxSizeError)},
-		{strings.Repeat(".", 254), mkMsgs(maxSizeError)},
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		"a.a", "ab.a", "abc.a", "a1.a", "a-1.a", "a--1--2--b.a",
+		"a.1", "ab.1", "abc.1", "a1.1", "a-1.1", "a--1--2--b.1",
+		"0.a", "01.a", "012.a", "1a.a", "1-a.a", "1--a--b--2",
+		"0.1", "01.1", "012.1", "1a.1", "1-a.1", "1--a--b--2.1",
+		"a.b.c.d.e", "aa.bb.cc.dd.ee", "1.2.3.4.5", "11.22.33.44.55",
+		strings.Repeat("a", 253),
+	}
+	for _, val := range goodValues {
+		if msgs := IsDNS1123Subdomain(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
 	}
 
-	for i, tc := range cases {
-		result := IsDNS1123Subdomain(tc.input)
-		testVerify(t, i, tc.input, tc.expect, result)
+	badValues := []string{
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a..b", "1.", ".1", "1..2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		"A.a", "aB.a", "ab.A", "A1.a", "a1.A",
+		"A.1", "aB.1", "A1.1", "1A.1",
+		"0.A", "01.A", "012.A", "1A.a", "1a.A",
+		"A.B.C.D.E", "AA.BB.CC.DD.EE", "a.B.c.d.e", "aa.bB.cc.dd.ee",
+		"a@b", "a,b", "a_b", "a;b",
+		"a:b", "a%b", "a?b", "a$b",
+		strings.Repeat("a", 254),
+	}
+	for _, val := range badValues {
+		if msgs := IsDNS1123Subdomain(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/errors.go
@@ -28,7 +28,7 @@ func MaxLenError(length int) string {
 
 // EmptyError returns a string explanation of an "empty string" validation.
 func EmptyError() string {
-	return "must contain at least 1 character"
+	return "must be non-empty"
 }
 
 // RegexError returns a string explanation of a regex validation failure.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/errors.go
@@ -30,3 +30,19 @@ func MaxLenError(length int) string {
 func EmptyError() string {
 	return "must contain at least 1 character"
 }
+
+// RegexError returns a string explanation of a regex validation failure.
+func RegexError(msg string, re string, examples ...string) string {
+	if len(examples) == 0 {
+		return msg + " (regex used for validation is '" + re + "')"
+	}
+	msg += " (e.g. "
+	for i := range examples {
+		if i > 0 {
+			msg += " or "
+		}
+		msg += "'" + examples[i] + "', "
+	}
+	msg += "regex used for validation is '" + re + "')"
+	return msg
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube_test.go
@@ -30,8 +30,7 @@ func TestIsQualifiedName(t *testing.T) {
 	const totalFailError = "must consist of a name .* and an optional DNS subdomain prefix"
 	const prefixMinSizeError = "prefix part: must contain at least 1 character"
 	const prefixMaxSizeError = "prefix part: must be no more than 253 characters"
-	const prefixStartEndError = "prefix part: each part must start and end with lower-case alphanumeric characters"
-	const prefixInteriorError = "prefix part: each part must contain only lower-case alphanumeric characters or '-'"
+	const prefixDNSLabelError = "prefix part:.* must consist of lower case alphanumeric.* must start and end with an alphanumeric"
 
 	cases := []struct {
 		input  string
@@ -66,8 +65,8 @@ func TestIsQualifiedName(t *testing.T) {
 		{"cantendwithadash-", mkMsgs(nameStartEndError)},
 		{"-cantstartwithadash-", mkMsgs(nameStartEndError)},
 		{"only/one/slash", mkMsgs(totalFailError)},
-		{"Example.com/abc", mkMsgs(prefixStartEndError)},
-		{"example_com/abc", mkMsgs(prefixInteriorError)},
+		{"Example.com/abc", mkMsgs(prefixDNSLabelError)},
+		{"example_com/abc", mkMsgs(prefixDNSLabelError)},
 		{"example.com/", mkMsgs(nameMinSizeError)},
 		{"/simple", mkMsgs(prefixMinSizeError)},
 		{strings.Repeat("a", 64), mkMsgs(nameMaxSizeError)},

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -424,20 +424,8 @@ func IsConfigMapKey(value string) []string {
 var MaxLenError = content.MaxLenError
 
 // RegexError returns a string explanation of a regex validation failure.
-func RegexError(msg string, fmt string, examples ...string) string {
-	if len(examples) == 0 {
-		return msg + " (regex used for validation is '" + fmt + "')"
-	}
-	msg += " (e.g. "
-	for i := range examples {
-		if i > 0 {
-			msg += " or "
-		}
-		msg += "'" + examples[i] + "', "
-	}
-	msg += "regex used for validation is '" + fmt + "')"
-	return msg
-}
+// Deprecated: Use k8s.io/apimachinery/pkg/api/validate/content.RegexError instead.
+var RegexError = content.RegexError
 
 // EmptyError returns a string explanation of a "must not be empty" validation
 // failure.

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -179,51 +179,6 @@ func TestIsValidPortName(t *testing.T) {
 	}
 }
 
-func TestIsQualifiedName(t *testing.T) {
-	successCases := []string{
-		"simple",
-		"now-with-dashes",
-		"1-starts-with-num",
-		"1234",
-		"simple/simple",
-		"now-with-dashes/simple",
-		"now-with-dashes/now-with-dashes",
-		"now.with.dots/simple",
-		"now-with.dashes-and.dots/simple",
-		"1-num.2-num/3-num",
-		"1234/5678",
-		"1.2.3.4/5678",
-		"Uppercase_Is_OK_123",
-		"example.com/Uppercase_Is_OK_123",
-		"requests.storage-foo",
-		strings.Repeat("a", 63),
-		strings.Repeat("a", 253) + "/" + strings.Repeat("b", 63),
-	}
-	for i := range successCases {
-		if errs := IsQualifiedName(successCases[i]); len(errs) != 0 {
-			t.Errorf("case[%d]: %q: expected success: %v", i, successCases[i], errs)
-		}
-	}
-
-	errorCases := []string{
-		"nospecialchars%^=@",
-		"cantendwithadash-",
-		"-cantstartwithadash-",
-		"only/one/slash",
-		"Example.com/abc",
-		"example_com/abc",
-		"example.com/",
-		"/simple",
-		strings.Repeat("a", 64),
-		strings.Repeat("a", 254) + "/abc",
-	}
-	for i := range errorCases {
-		if errs := IsQualifiedName(errorCases[i]); len(errs) == 0 {
-			t.Errorf("case[%d]: %q: expected failure", i, errorCases[i])
-		}
-	}
-}
-
 func TestIsValidIP(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -691,11 +691,11 @@ func TestIsFullyQualifiedName(t *testing.T) {
 	}, {
 		name:       "name should not include scheme",
 		targetName: "http://foo.k8s.io",
-		err:        "each part must contain only lower-case alphanumeric characters or '-'",
+		err:        "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters",
 	}, {
 		name:       "email should be invalid",
 		targetName: "example@foo.k8s.io",
-		err:        "each part must contain only lower-case alphanumeric characters or '-'",
+		err:        "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters",
 	}, {
 		name:       "name cannot be empty",
 		targetName: "",
@@ -703,7 +703,7 @@ func TestIsFullyQualifiedName(t *testing.T) {
 	}, {
 		name:       "name must conform to RFC 1123",
 		targetName: "A.B.C",
-		err:        "each part must start and end with lower-case alphanumeric characters",
+		err:        "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters",
 	}}
 	for _, tc := range messageTests {
 		err := IsFullyQualifiedName(field.NewPath(""), tc.targetName).ToAggregate()

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -180,6 +180,9 @@ func TestIsValidPortName(t *testing.T) {
 }
 
 func TestIsValidIP(t *testing.T) {
+	// IsValidIP is a wrapper of validate.IPSloppy, but it's not just an alias,
+	// so we will retain these tests until all callers of IsValidIP are
+	// removed.
 	for _, tc := range []struct {
 		name   string
 		in     string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
@@ -53,10 +53,10 @@ func Test(t *testing.T) {
 	}).ExpectInvalid(
 		field.Invalid(field.NewPath("ipField"), "", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
 		field.Invalid(field.NewPath("ipPtrField"), "", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
-		field.Invalid(field.NewPath("dnsLabelField"), "", "must contain at least 1 character"),
-		field.Invalid(field.NewPath("dnsLabelPtrField"), "", "must contain at least 1 character"),
+		field.Invalid(field.NewPath("dnsLabelField"), "", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
+		field.Invalid(field.NewPath("dnsLabelPtrField"), "", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 		field.Invalid(field.NewPath("ipTypedefField"), "", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
-		field.Invalid(field.NewPath("dnsLabelTypedefField"), "", "must contain at least 1 character"),
+		field.Invalid(field.NewPath("dnsLabelTypedefField"), "", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 	)
 
 	st.Value(&Struct{
@@ -69,12 +69,9 @@ func Test(t *testing.T) {
 	}).ExpectInvalid(
 		field.Invalid(field.NewPath("ipField"), "Not an IP", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
 		field.Invalid(field.NewPath("ipPtrField"), "Not an IP", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
-		field.Invalid(field.NewPath("dnsLabelField"), "Not a DNS label", "must start and end with lower-case alphanumeric characters"),
-		field.Invalid(field.NewPath("dnsLabelField"), "Not a DNS label", "must contain only lower-case alphanumeric characters or '-'"),
-		field.Invalid(field.NewPath("dnsLabelPtrField"), "Not a DNS label", "must start and end with lower-case alphanumeric characters"),
-		field.Invalid(field.NewPath("dnsLabelPtrField"), "Not a DNS label", "must contain only lower-case alphanumeric characters or '-'"),
+		field.Invalid(field.NewPath("dnsLabelField"), "Not a DNS label", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
+		field.Invalid(field.NewPath("dnsLabelPtrField"), "Not a DNS label", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 		field.Invalid(field.NewPath("ipTypedefField"), "Not an IP", "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)"),
-		field.Invalid(field.NewPath("dnsLabelTypedefField"), "Not a DNS label", "must start and end with lower-case alphanumeric characters"),
-		field.Invalid(field.NewPath("dnsLabelTypedefField"), "Not a DNS label", "must contain only lower-case alphanumeric characters or '-'"),
+		field.Invalid(field.NewPath("dnsLabelTypedefField"), "Not a DNS label", "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')"),
 	)
 }


### PR DESCRIPTION
I decided the fixes to tests were too risky for now and reverted the message changes.  The dns-label and qualified-name code is now a DIRECT port from the old.