### PR TITLE
Add Origin to Invalid errors for generated validations

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
@@ -31,7 +31,7 @@ func MaxLength[T ~string](_ context.Context, _ operation.Operation, fldPath *fie
 		return nil
 	}
 	if len(*value) > max {
-		return field.ErrorList{field.Invalid(fldPath, *value, content.MaxLenError(max))}
+		return field.ErrorList{field.Invalid(fldPath, *value, content.MaxLenError(max)).WithOrigin("maxLength")}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
@@ -39,7 +39,7 @@ func DNSLabel[T ~string](_ context.Context, op operation.Operation, fldPath *fie
 	}
 	var allErrs field.ErrorList
 	for _, msg := range content.IsDNS1123Label((string)(*value)) {
-		allErrs = append(allErrs, field.Invalid(fldPath, *value, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, *value, msg).WithOrigin("format=dns-label"))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/testing.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/testing.go
@@ -30,6 +30,6 @@ func FixedResult[T any](_ context.Context, op operation.Operation, fldPath *fiel
 		return nil
 	}
 	return field.ErrorList{
-		field.Invalid(fldPath, value, "forced failure: "+arg),
+		field.Invalid(fldPath, value, "forced failure: "+arg).WithOrigin("validateFalse"),
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -44,6 +44,9 @@ type Error struct {
 	// - A structured format using "format=<dash-style-identifier>" for validation errors related to specific formats
 	//   (e.g., "format=dns-label", "format=qualified-name")
 	//
+	// If the Origin corresponds to an existing declarative validation tag or JSON Schema keyword,
+	// use that same name for consistency.
+	//
 	// Origin should be set in the most deeply nested validation function that
 	// can still identify the unique source of the error.
 	Origin string


### PR DESCRIPTION
This PR adds the Origin to the Invalid() errors from the generated validations.

Note: It doesn't include the Invalid errors for the "union" as it is still being decided on the naming for it.