### PR TITLE
feat: add declarative_validation_mismatch_total metric and associated declarative validation runtime verification tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -25,7 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	fldtest "k8s.io/apimachinery/pkg/util/validation/field/testing"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	validationmetrics "k8s.io/apiserver/pkg/validation"
+	"k8s.io/klog/v2"
 )
 
 // ValidateDeclaratively validates obj against declarative validation tags
@@ -105,4 +108,211 @@ func parseSubresourcePath(subresourcePath string) ([]string, error) {
 	}
 	parts := strings.Split(subresourcePath[1:], "/")
 	return parts, nil
+}
+
+// CompareDeclarativeErrorsAndEmitMismatches checks for mismatches between imperative and declarative validation
+// and logs + emits metrics when inconsistencies are found
+func CompareDeclarativeErrorsAndEmitMismatches(imperativeErrs, declarativeErrs field.ErrorList, takeover bool) {
+	mismatchDetails := gatherDeclarativeValidationMismatches(imperativeErrs, declarativeErrs, takeover)
+	for _, detail := range mismatchDetails {
+		// Log information about the mismatch
+		klog.Warning(detail)
+
+		// Increment the metric for the mismatch
+		validationmetrics.Metrics.EmitDeclarativeValidationMismatchMetric()
+	}
+}
+
+// gatherDeclarativeValidationMismatches compares imperative and declarative validation errors
+// and returns detailed information about any mismatches found. Errors are compared via type, field, and origin
+func gatherDeclarativeValidationMismatches(imperativeErrs, declarativeErrs field.ErrorList, takeover bool) []string {
+	var mismatchDetails []string
+	// short circuit here to minimize allocs for usual case of 0 validation errors
+	if len(imperativeErrs) == 0 && len(declarativeErrs) == 0 {
+		return mismatchDetails
+	}
+	// recommendation based on takeover status
+	recommendation := "This difference should not affect system operation since hand written validation is authoritative."
+	if takeover {
+		recommendation = "Consider disabling the DeclarativeValidationTakeover feature gate."
+	}
+	fuzzyMatcher := fldtest.ErrorMatcher{}.ByType().ByField().ByOrigin().RequireOriginWhenInvalid()
+	exactMatcher := fldtest.ErrorMatcher{}.Exactly()
+
+	// Dedupe imperative errors of exact error matches as they are
+	// not intended and come from (buggy) duplicate validation calls
+	// This is necessary as without deduping we could get unmatched
+	// imperative errors for cases that are correct (matching)
+	dedupedImperativeErrs := field.ErrorList{}
+	for _, err := range imperativeErrs {
+		found := false
+		for _, existingErr := range dedupedImperativeErrs {
+			if exactMatcher.Matches(existingErr, err) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			dedupedImperativeErrs = append(dedupedImperativeErrs, err)
+		}
+	}
+	imperativeErrs = dedupedImperativeErrs
+
+	// Create a copy of declarative errors to track remaining ones
+	remaining := make(field.ErrorList, len(declarativeErrs))
+	copy(remaining, declarativeErrs)
+
+	// Match each "covered" imperative error to declarative errors.
+	// We use a fuzzy matching approach to find corresponding declarative errors
+	// for each imperative error marked as CoveredByDeclarative.
+	// As matches are found, they're removed from the 'remaining' list.
+	// They are removed from `remaining` with a "1:many" mapping: for a given
+	// imperative error we mark as matched all matching declarative errors
+	// This allows us to:
+	// 1. Detect imperative errors that should have matching declarative errors but don't
+	// 2. Identify extra declarative errors with no imperative counterpart
+	// Both cases indicate issues with the declarative validation implementation.
+	for _, iErr := range imperativeErrs {
+		if !iErr.CoveredByDeclarative {
+			continue
+		}
+
+		tmp := make(field.ErrorList, 0, len(remaining))
+		matchCount := 0
+
+		for _, dErr := range remaining {
+			if fuzzyMatcher.Matches(iErr, dErr) {
+				matchCount++
+			} else {
+				tmp = append(tmp, dErr)
+			}
+		}
+
+		if matchCount == 0 {
+			mismatchDetails = append(mismatchDetails,
+				fmt.Sprintf(
+					"Unexpected difference between hand written validation and declarative validation error results, unmatched error(s) found %s. "+
+						"This may indicate an issue with declarative validation. %s",
+					fuzzyMatcher.Render(iErr),
+					recommendation,
+				),
+			)
+		}
+
+		remaining = tmp
+	}
+
+	// Any remaining unmatched declarative errors are considered "extra"
+	for _, dErr := range remaining {
+		mismatchDetails = append(mismatchDetails,
+			fmt.Sprintf(
+				"Unexpected difference between hand written validation and declarative validation error results, extra error(s) found %s. "+
+					"This may indicate an issue with declarative validation. %s",
+				fuzzyMatcher.Render(dErr),
+				recommendation,
+			),
+		)
+	}
+
+	return mismatchDetails
+}
+
+// createDeclarativeValidationPanicHandler returns a function with panic recovery logic
+// that will increment the panic metric and either log or append errors based on the takeover parameter.
+func createDeclarativeValidationPanicHandler(errs *field.ErrorList, takeover bool) func() {
+	return func() {
+		if r := recover(); r != nil {
+			// Increment the panic metric counter
+			validationmetrics.Metrics.EmitDeclarativeValidationPanicMetric()
+
+			const errorFmt = "panic during declarative validation: %v"
+			if takeover {
+				// If takeover is enabled, output as a validation error as authorative validator panicked and validation should error
+				*errs = append(*errs, field.InternalError(nil, fmt.Errorf(errorFmt, r)))
+			} else {
+				// if takeover not enabled, log the panic as a warning
+				klog.Warningf(errorFmt, r)
+			}
+		}
+	}
+}
+
+// withRecover wraps a validation function with panic recovery logic.
+// It takes a validation function with the ValidateDeclaratively signature
+// and returns a function with the same signature.
+// The returned function will execute the wrapped function and handle any panics by
+// incrementing the panic metric, and logging an error message
+// if takeover=false, and adding a validation error if takeover=true.
+func withRecover(
+	validateFunc func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj runtime.Object) field.ErrorList,
+	takeover bool,
+) func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj runtime.Object) field.ErrorList {
+	return func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj runtime.Object) (errs field.ErrorList) {
+		defer createDeclarativeValidationPanicHandler(&errs, takeover)()
+
+		return validateFunc(ctx, options, scheme, obj)
+	}
+}
+
+// withRecoverUpdate wraps an update validation function with panic recovery logic.
+// It takes a validation function with the ValidateUpdateDeclaratively signature
+// and returns a function with the same signature.
+// The returned function will execute the wrapped function and handle any panics by
+// incrementing the panic metric, and logging an error message
+// if takeover=false, and adding a validation error if takeover=true.
+func withRecoverUpdate(
+	validateUpdateFunc func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj, oldObj runtime.Object) field.ErrorList,
+	takeover bool,
+) func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj, oldObj runtime.Object) field.ErrorList {
+	return func(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj, oldObj runtime.Object) (errs field.ErrorList) {
+		defer createDeclarativeValidationPanicHandler(&errs, takeover)()
+
+		return validateUpdateFunc(ctx, options, scheme, obj, oldObj)
+	}
+}
+
+// ValidateDeclarativelyWithRecovery validates obj against declarative validation tags
+// with panic recovery logic. It uses the API version extracted from ctx and the
+// provided scheme for validation.
+//
+// The ctx MUST contain requestInfo, which determines the target API for
+// validation. The obj is converted to the API version using the provided scheme
+// before validation occurs. The scheme MUST have the declarative validation
+// registered for the requested resource/subresource.
+//
+// option should contain any validation options that the declarative validation
+// tags expect.
+//
+// takeover determines if panic recovery should return validation errors (true) or
+// just log warnings (false).
+//
+// Returns a field.ErrorList containing any validation errors. An internal error
+// is included if requestInfo is missing from the context, if version
+// conversion fails, or if a panic occurs during validation when
+// takeover is true.
+func ValidateDeclarativelyWithRecovery(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj runtime.Object, takeover bool) field.ErrorList {
+	return withRecover(ValidateDeclaratively, takeover)(ctx, options, scheme, obj)
+}
+
+// ValidateUpdateDeclarativelyWithRecovery validates obj and oldObj against declarative
+// validation tags with panic recovery logic. It uses the API version extracted from
+// ctx and the provided scheme for validation.
+//
+// The ctx MUST contain requestInfo, which determines the target API for
+// validation. The obj is converted to the API version using the provided scheme
+// before validation occurs. The scheme MUST have the declarative validation
+// registered for the requested resource/subresource.
+//
+// option should contain any validation options that the declarative validation
+// tags expect.
+//
+// takeover determines if panic recovery should return validation errors (true) or
+// just log warnings (false).
+//
+// Returns a field.ErrorList containing any validation errors. An internal error
+// is included if requestInfo is missing from the context, if version
+// conversion fails, or if a panic occurs during validation when
+// takeover is true.
+func ValidateUpdateDeclarativelyWithRecovery(ctx context.Context, options sets.Set[string], scheme *runtime.Scheme, obj, oldObj runtime.Object, takeover bool) field.ErrorList {
+	return withRecoverUpdate(ValidateUpdateDeclaratively, takeover)(ctx, options, scheme, obj, oldObj)
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -17,8 +17,13 @@ limitations under the License.
 package rest
 
 import (
+	"bytes"
 	"context"
+	"flag"
 	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	fieldtesting "k8s.io/apimachinery/pkg/util/validation/field/testing"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
 )
 
 func TestValidateDeclaratively(t *testing.T) {
@@ -181,4 +187,438 @@ func (p Pod) DeepCopyObject() runtime.Object {
 		},
 		RestartPolicy: p.RestartPolicy,
 	}
+}
+
+// TestCheckDeclarativeValidationMismatches tests all scenarios for
+// the gatherDeclarativeValidationMismatches function
+func TestGatherDeclarativeValidationMismatches(t *testing.T) {
+	replicasPath := field.NewPath("spec").Child("replicas")
+	minReadySecondsPath := field.NewPath("spec").Child("minReadySeconds")
+	selectorPath := field.NewPath("spec").Child("selector")
+
+	errA := field.Invalid(replicasPath, nil, "regular error A")
+	errB := field.Invalid(minReadySecondsPath, -1, "covered error B").WithOrigin("minimum")
+	coveredErrB := field.Invalid(minReadySecondsPath, -1, "covered error B").WithOrigin("minimum")
+	errBWithDiffDetail := field.Invalid(minReadySecondsPath, -1, "covered error B - different detail").WithOrigin("minimum")
+	coveredErrB.CoveredByDeclarative = true
+	errC := field.Invalid(replicasPath, nil, "covered error C").WithOrigin("minimum")
+	coveredErrC := field.Invalid(replicasPath, nil, "covered error C").WithOrigin("minimum")
+	coveredErrC.CoveredByDeclarative = true
+	errCWithDiffOrigin := field.Invalid(replicasPath, nil, "covered error C").WithOrigin("maximum")
+	errD := field.Invalid(selectorPath, nil, "regular error D")
+
+	tests := []struct {
+		name                    string
+		imperativeErrors        field.ErrorList
+		declarativeErrors       field.ErrorList
+		takeover                bool
+		expectMismatches        bool
+		expectDetailsContaining []string
+	}{
+		{
+			name:                    "Declarative and imperative return 0 errors - no mismatch",
+			imperativeErrors:        field.ErrorList{},
+			declarativeErrors:       field.ErrorList{},
+			takeover:                false,
+			expectMismatches:        false,
+			expectDetailsContaining: []string{},
+		},
+		{
+			name: "Declarative returns multiple errors with different origins, errors match - no mismatch",
+			imperativeErrors: field.ErrorList{
+				errA,
+				coveredErrB,
+				coveredErrC,
+				errD,
+			},
+			declarativeErrors: field.ErrorList{
+				errB,
+				errC,
+			},
+			takeover:                false,
+			expectMismatches:        false,
+			expectDetailsContaining: []string{},
+		},
+		{
+			name: "Declarative returns multiple errors with different origins, errors don't match - mismatch case",
+			imperativeErrors: field.ErrorList{
+				errA,
+				coveredErrB,
+				coveredErrC,
+			},
+			declarativeErrors: field.ErrorList{
+				errB,
+				errCWithDiffOrigin,
+			},
+			takeover:         true,
+			expectMismatches: true,
+			expectDetailsContaining: []string{
+				"Unexpected difference between hand written validation and declarative validation error results",
+				"unmatched error(s) found",
+				"extra error(s) found",
+				"replicas",
+				"Consider disabling the DeclarativeValidationTakeover feature gate",
+			},
+		},
+		{
+			name: "Declarative and imperative return exactly 1 error, errors match - no mismatch",
+			imperativeErrors: field.ErrorList{
+				coveredErrB,
+			},
+			declarativeErrors: field.ErrorList{
+				errB,
+			},
+			takeover:                false,
+			expectMismatches:        false,
+			expectDetailsContaining: []string{},
+		},
+		{
+			name: "Declarative and imperative exactly 1 error, errors don't match - mismatch",
+			imperativeErrors: field.ErrorList{
+				coveredErrB,
+			},
+			declarativeErrors: field.ErrorList{
+				errC,
+			},
+			takeover:         false,
+			expectMismatches: true,
+			expectDetailsContaining: []string{
+				"Unexpected difference between hand written validation and declarative validation error results",
+				"unmatched error(s) found",
+				"minReadySeconds",
+				"extra error(s) found",
+				"replicas",
+				"This difference should not affect system operation since hand written validation is authoritative",
+			},
+		},
+		{
+			name: "Declarative returns 0 errors, imperative returns 1 covered error - mismatch",
+			imperativeErrors: field.ErrorList{
+				coveredErrB,
+			},
+			declarativeErrors: field.ErrorList{},
+			takeover:          true,
+			expectMismatches:  true,
+			expectDetailsContaining: []string{
+				"Unexpected difference between hand written validation and declarative validation error results",
+				"unmatched error(s) found",
+				"minReadySeconds",
+				"Consider disabling the DeclarativeValidationTakeover feature gate",
+			},
+		},
+		{
+			name: "Declarative returns 0 errors, imperative returns 1 uncovered error - no mismatch",
+			imperativeErrors: field.ErrorList{
+				errB,
+			},
+			declarativeErrors:       field.ErrorList{},
+			takeover:                false,
+			expectMismatches:        false,
+			expectDetailsContaining: []string{},
+		},
+		{
+			name:             "Declarative returns 1 error, imperative returns 0 error - mismatch",
+			imperativeErrors: field.ErrorList{},
+			declarativeErrors: field.ErrorList{
+				errB,
+			},
+			takeover:         false,
+			expectMismatches: true,
+			expectDetailsContaining: []string{
+				"Unexpected difference between hand written validation and declarative validation error results",
+				"extra error(s) found",
+				"minReadySeconds",
+				"This difference should not affect system operation since hand written validation is authoritative",
+			},
+		},
+		{
+			name: "Declarative returns 1 error, imperative returns 3 matching errors  - no mismatch",
+			imperativeErrors: field.ErrorList{
+				coveredErrB,
+			},
+			declarativeErrors: field.ErrorList{
+				errB,
+				errB,
+				errBWithDiffDetail,
+			},
+			takeover:                false,
+			expectMismatches:        false,
+			expectDetailsContaining: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			details := gatherDeclarativeValidationMismatches(tt.imperativeErrors, tt.declarativeErrors, tt.takeover)
+			// Check if mismatches were found if expected
+			if tt.expectMismatches && len(details) == 0 {
+				t.Errorf("Expected mismatches but got none")
+			}
+			// Check if details contain expected text
+			detailsStr := strings.Join(details, " ")
+			for _, expectedContent := range tt.expectDetailsContaining {
+				if !strings.Contains(detailsStr, expectedContent) {
+					t.Errorf("Expected details to contain: %q, but they didn't.\nDetails were:\n%s",
+						expectedContent, strings.Join(details, "\n"))
+				}
+			}
+			// If we don't expect any details, make sure none provided
+			if len(tt.expectDetailsContaining) == 0 && len(details) > 0 {
+				t.Errorf("Expected no details, but got %d details: %v", len(details), details)
+			}
+		})
+	}
+}
+
+func TestWithRecover(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	options := sets.New[string]()
+	obj := &runtime.Unknown{}
+
+	tests := []struct {
+		name            string
+		validateFn      func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object) field.ErrorList
+		takeoverEnabled bool
+		wantErrs        field.ErrorList
+		expectLogRegex  string
+	}{
+		{
+			name: "no panic",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object) field.ErrorList {
+				return field.ErrorList{
+					field.Invalid(field.NewPath("field"), "value", "reason"),
+				}
+			},
+			takeoverEnabled: false,
+			wantErrs: field.ErrorList{
+				field.Invalid(field.NewPath("field"), "value", "reason"),
+			},
+			expectLogRegex: "",
+		},
+		{
+			name: "panic with takeover disabled",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object) field.ErrorList {
+				panic("test panic")
+			},
+			takeoverEnabled: false,
+			wantErrs:        nil,
+			// logs have a prefix of the form - W0309 21:05:33.865030 1926106 validate.go:199]
+			expectLogRegex: "W.*panic during declarative validation: test panic",
+		},
+		{
+			name: "panic with takeover enabled",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object) field.ErrorList {
+				panic("test panic")
+			},
+			takeoverEnabled: true,
+			wantErrs: field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("panic during declarative validation: test panic")),
+			},
+			expectLogRegex: "",
+		},
+		{
+			name: "nil return, no panic",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object) field.ErrorList {
+				return nil // no errors, no panic
+			},
+			takeoverEnabled: false,
+			wantErrs:        nil,
+			expectLogRegex:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			flag.Set("v", "6")
+			flag.Parse()
+			klog.SetOutput(&buf)
+			klog.LogToStderr(false)
+			defer klog.LogToStderr(true)
+
+			// Pass the takeover flag to withRecover instead of relying on the feature gate
+			wrapped := withRecover(tt.validateFn, tt.takeoverEnabled)
+			gotErrs := wrapped(ctx, options, scheme, obj)
+
+			klog.Flush()
+			logOutput := buf.String()
+
+			// Compare gotErrs vs. tt.wantErrs
+			if !equalErrorLists(gotErrs, tt.wantErrs) {
+				t.Errorf("withRecover() gotErrs = %#v, want %#v", gotErrs, tt.wantErrs)
+			}
+
+			// Check logs if needed
+			if tt.expectLogRegex != "" {
+				matched, err := regexp.MatchString(tt.expectLogRegex, logOutput)
+				if err != nil {
+					t.Fatalf("Bad regex: %v", err)
+				}
+				if !matched {
+					t.Errorf("Expected log output %q, but got:\n%s", tt.expectLogRegex, logOutput)
+				}
+			} else if strings.Contains(logOutput, "panic during declarative validation") {
+				t.Errorf("Unexpected panic log found: %s", logOutput)
+			}
+		})
+	}
+}
+
+func TestWithRecoverUpdate(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	options := sets.New[string]()
+	obj := &runtime.Unknown{}
+	oldObj := &runtime.Unknown{}
+
+	tests := []struct {
+		name            string
+		validateFn      func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object, runtime.Object) field.ErrorList
+		takeoverEnabled bool
+		wantErrs        field.ErrorList
+		expectLogRegex  string
+	}{
+		{
+			name: "no panic",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object, runtime.Object) field.ErrorList {
+				return field.ErrorList{
+					field.Invalid(field.NewPath("field"), "value", "reason"),
+				}
+			},
+			takeoverEnabled: false,
+			wantErrs: field.ErrorList{
+				field.Invalid(field.NewPath("field"), "value", "reason"),
+			},
+			expectLogRegex: "",
+		},
+		{
+			name: "panic with takeover disabled",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object, runtime.Object) field.ErrorList {
+				panic("test update panic")
+			},
+			takeoverEnabled: false,
+			wantErrs:        nil,
+			// logs have a prefix of the form - W0309 21:05:33.865030 1926106 validate.go:199]
+			expectLogRegex: "W.*panic during declarative validation: test update panic",
+		},
+		{
+			name: "panic with takeover enabled",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object, runtime.Object) field.ErrorList {
+				panic("test update panic")
+			},
+			takeoverEnabled: true,
+			wantErrs: field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("panic during declarative validation: test update panic")),
+			},
+			expectLogRegex: "",
+		},
+		{
+			name: "nil return, no panic",
+			validateFn: func(context.Context, sets.Set[string], *runtime.Scheme, runtime.Object, runtime.Object) field.ErrorList {
+				return nil
+			},
+			takeoverEnabled: false,
+			wantErrs:        nil,
+			expectLogRegex:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			flag.Set("v", "6")
+			flag.Parse()
+			klog.SetOutput(&buf)
+			klog.LogToStderr(false)
+			defer klog.LogToStderr(true)
+
+			// Pass the takeover flag to withRecoverUpdate instead of relying on the feature gate
+			wrapped := withRecoverUpdate(tt.validateFn, tt.takeoverEnabled)
+			gotErrs := wrapped(ctx, options, scheme, obj, oldObj)
+
+			klog.Flush()
+			logOutput := buf.String()
+
+			// Compare gotErrs with wantErrs
+			if !equalErrorLists(gotErrs, tt.wantErrs) {
+				t.Errorf("withRecoverUpdate() gotErrs = %#v, want %#v", gotErrs, tt.wantErrs)
+			}
+
+			// Verify log output
+			if tt.expectLogRegex != "" {
+				matched, err := regexp.MatchString(tt.expectLogRegex, logOutput)
+				if err != nil {
+					t.Fatalf("Bad regex: %v", err)
+				}
+				if !matched {
+					t.Errorf("Expected log pattern %q, but got:\n%s", tt.expectLogRegex, logOutput)
+				}
+			} else if strings.Contains(logOutput, "panic during declarative validation") {
+				t.Errorf("Unexpected panic log found: %s", logOutput)
+			}
+		})
+	}
+}
+
+func TestValidateDeclarativelyWithRecovery(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	options := sets.New[string]()
+	obj := &runtime.Unknown{}
+
+	// Simple test for the ValidateDeclarativelyWithRecovery function
+	t.Run("with takeover disabled", func(t *testing.T) {
+		errs := ValidateDeclarativelyWithRecovery(ctx, options, scheme, obj, false)
+		if errs == nil {
+			// This is expected to error since the request info is missing
+			t.Errorf("Expected errors but got nil")
+		}
+	})
+
+	t.Run("with takeover enabled", func(t *testing.T) {
+		errs := ValidateDeclarativelyWithRecovery(ctx, options, scheme, obj, true)
+		if errs == nil {
+			// This is expected to error since the request info is missing
+			t.Errorf("Expected errors but got nil")
+		}
+	})
+}
+
+func TestValidateUpdateDeclarativelyWithRecovery(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	options := sets.New[string]()
+	obj := &runtime.Unknown{}
+	oldObj := &runtime.Unknown{}
+
+	// Simple test for the ValidateUpdateDeclarativelyWithRecovery function
+	t.Run("with takeover disabled", func(t *testing.T) {
+		errs := ValidateUpdateDeclarativelyWithRecovery(ctx, options, scheme, obj, oldObj, false)
+		if errs == nil {
+			// This is expected to error since the request info is missing
+			t.Errorf("Expected errors but got nil")
+		}
+	})
+
+	t.Run("with takeover enabled", func(t *testing.T) {
+		errs := ValidateUpdateDeclarativelyWithRecovery(ctx, options, scheme, obj, oldObj, true)
+		if errs == nil {
+			// This is expected to error since the request info is missing
+			t.Errorf("Expected errors but got nil")
+		}
+	})
+}
+
+func equalErrorLists(a, b field.ErrorList) bool {
+	// If both are nil, consider them equal
+	if a == nil && b == nil {
+		return true
+	}
+	// If one is nil and the other not, they're different
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	// Both non-nil: do a normal DeepEqual
+	return reflect.DeepEqual(a, b)
 }

--- a/staging/src/k8s.io/apiserver/pkg/validation/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/validation/metrics.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "apiserver" // Keep it consistent; apiserver is handling it
+	subsystem = "validation"
+)
+
+// Separate counter options variable for reuse during reset.
+var declarativeValidationMismatchCounterOpts = &metrics.CounterOpts{
+	Namespace:      namespace,
+	Subsystem:      subsystem,
+	Name:           "declarative_validation_mismatch_total",
+	Help:           "Number of times declarative validation results differed from handwritten validation results for core types.",
+	StabilityLevel: metrics.BETA,
+}
+
+// Counter options for declarative validation panics
+var declarativeValidationPanicCounterOpts = &metrics.CounterOpts{
+	Namespace:      namespace,
+	Subsystem:      subsystem,
+	Name:           "declarative_validation_panic_total",
+	Help:           "Number of times declarative validation has panicked during validation.",
+	StabilityLevel: metrics.BETA,
+}
+
+// ValidationMetrics is the interface for validation metrics.
+type ValidationMetrics interface {
+	EmitDeclarativeValidationMismatchMetric()
+	EmitDeclarativeValidationPanicMetric()
+	Reset()
+}
+
+var validationMetricsInstance = &validationMetrics{
+	DeclarativeValidationMismatchCounter: metrics.NewCounter(declarativeValidationMismatchCounterOpts),
+	DeclarativeValidationPanicCounter:    metrics.NewCounter(declarativeValidationPanicCounterOpts),
+}
+
+// Metrics provides access to validation metrics.
+var Metrics ValidationMetrics = validationMetricsInstance
+
+func init() {
+	legacyregistry.MustRegister(validationMetricsInstance.DeclarativeValidationMismatchCounter)
+	legacyregistry.MustRegister(validationMetricsInstance.DeclarativeValidationPanicCounter)
+}
+
+type validationMetrics struct {
+	DeclarativeValidationMismatchCounter *metrics.Counter
+	DeclarativeValidationPanicCounter    *metrics.Counter
+}
+
+// Reset resets the validation metrics.
+func (m *validationMetrics) Reset() {
+	m.DeclarativeValidationMismatchCounter = metrics.NewCounter(declarativeValidationMismatchCounterOpts)
+	m.DeclarativeValidationPanicCounter = metrics.NewCounter(declarativeValidationPanicCounterOpts)
+}
+
+// EmitDeclarativeValidationMismatchMetric increments the counter for the declarative_validation_mismatch_total metric.
+func (m *validationMetrics) EmitDeclarativeValidationMismatchMetric() {
+	m.DeclarativeValidationMismatchCounter.Inc()
+}
+
+// EmitDeclarativeValidationPanicMetric increments the counter for the declarative_validation_panic_total metric.
+func (m *validationMetrics) EmitDeclarativeValidationPanicMetric() {
+	m.DeclarativeValidationPanicCounter.Inc()
+}
+
+func ResetValidationMetricsInstance() {
+	validationMetricsInstance.Reset()
+}

--- a/staging/src/k8s.io/apiserver/pkg/validation/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/validation/metrics_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+// TestDeclarativeValidationMismatchMetric tests that the mismatch metric correctly increments once
+func TestDeclarativeValidationMismatchMetric(t *testing.T) {
+	defer legacyregistry.Reset()
+	defer ResetValidationMetricsInstance()
+
+	// Increment the metric once
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+
+	expected := `
+	# HELP apiserver_validation_declarative_validation_mismatch_total [BETA] Number of times declarative validation results differed from handwritten validation results for core types.
+	# TYPE apiserver_validation_declarative_validation_mismatch_total counter
+	apiserver_validation_declarative_validation_mismatch_total 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_mismatch_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeclarativeValidationPanicMetric tests that the panic metric correctly increments once
+func TestDeclarativeValidationPanicMetric(t *testing.T) {
+	defer legacyregistry.Reset()
+	defer ResetValidationMetricsInstance()
+
+	// Increment the metric once
+	Metrics.EmitDeclarativeValidationPanicMetric()
+
+	expected := `
+	# HELP apiserver_validation_declarative_validation_panic_total [BETA] Number of times declarative validation has panicked during validation.
+	# TYPE apiserver_validation_declarative_validation_panic_total counter
+	apiserver_validation_declarative_validation_panic_total 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_panic_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeclarativeValidationMismatchMetricMultiple tests that the mismatch metric correctly increments multiple times
+func TestDeclarativeValidationMismatchMetricMultiple(t *testing.T) {
+	defer legacyregistry.Reset()
+	defer ResetValidationMetricsInstance()
+
+	// Increment the metric three times
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+
+	expected := `
+	# HELP apiserver_validation_declarative_validation_mismatch_total [BETA] Number of times declarative validation results differed from handwritten validation results for core types.
+	# TYPE apiserver_validation_declarative_validation_mismatch_total counter
+	apiserver_validation_declarative_validation_mismatch_total 3
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_mismatch_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeclarativeValidationPanicMetricMultiple tests that the panic metric correctly increments multiple times
+func TestDeclarativeValidationPanicMetricMultiple(t *testing.T) {
+	defer legacyregistry.Reset()
+	defer ResetValidationMetricsInstance()
+
+	// Increment the metric three times
+	Metrics.EmitDeclarativeValidationPanicMetric()
+	Metrics.EmitDeclarativeValidationPanicMetric()
+	Metrics.EmitDeclarativeValidationPanicMetric()
+
+	expected := `
+	# HELP apiserver_validation_declarative_validation_panic_total [BETA] Number of times declarative validation has panicked during validation.
+	# TYPE apiserver_validation_declarative_validation_panic_total counter
+	apiserver_validation_declarative_validation_panic_total 3
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_panic_total"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeclarativeValidationMetricsReset tests that the Reset function correctly resets the metrics to zero
+func TestDeclarativeValidationMetricsReset(t *testing.T) {
+	defer legacyregistry.Reset()
+	defer ResetValidationMetricsInstance()
+
+	// Increment both metrics
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+	Metrics.EmitDeclarativeValidationPanicMetric()
+
+	// Reset the metrics
+	Metrics.Reset()
+
+	// Verify they've been reset to zero
+	expected := `
+	# HELP apiserver_validation_declarative_validation_mismatch_total [BETA] Number of times declarative validation results differed from handwritten validation results for core types.
+	# TYPE apiserver_validation_declarative_validation_mismatch_total counter
+	apiserver_validation_declarative_validation_mismatch_total 0
+	# HELP apiserver_validation_declarative_validation_panic_total [BETA] Number of times declarative validation has panicked during validation.
+	# TYPE apiserver_validation_declarative_validation_panic_total counter
+	apiserver_validation_declarative_validation_panic_total 0
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_mismatch_total", "declarative_validation_panic_total"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Increment the metrics again to ensure they're still functional
+	Metrics.EmitDeclarativeValidationMismatchMetric()
+	Metrics.EmitDeclarativeValidationPanicMetric()
+
+	// Verify they've been incremented correctly
+	expected = `
+	# HELP apiserver_validation_declarative_validation_mismatch_total [BETA] Number of times declarative validation results differed from handwritten validation results for core types.
+	# TYPE apiserver_validation_declarative_validation_mismatch_total counter
+	apiserver_validation_declarative_validation_mismatch_total 1
+	# HELP apiserver_validation_declarative_validation_panic_total [BETA] Number of times declarative validation has panicked during validation.
+	# TYPE apiserver_validation_declarative_validation_panic_total counter
+	apiserver_validation_declarative_validation_panic_total 1
+	`
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "declarative_validation_mismatch_total", "declarative_validation_panic_total"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds the declarative_validation_mismatch_total metric as well as runtime verification testing to validation-gen
