### PR TITLE
chore(validation-gen): rename flag --extra-pkg -> --readonly-pkg in validation-gen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -434,7 +434,7 @@ function codegen::validation() {
     # main API types. Validations defined on types in these packages will be
     # used, but not regenerated, unless they are also listed as a "regular"
     # input on the command-line.
-    local extra_pkgs=(
+    local readonly_pkgs=(
         k8s.io/apimachinery/pkg/apis/meta/v1
         k8s.io/apimachinery/pkg/api/resource
         k8s.io/apimachinery/pkg/runtime
@@ -457,7 +457,7 @@ function codegen::validation() {
         -v "${KUBE_VERBOSE}" \
         --go-header-file "${BOILERPLATE_FILENAME}" \
         --output-file "${output_file}" \
-        $(printf -- " --extra-pkg %s" "${extra_pkgs[@]}") \
+        $(printf -- " --readonly-pkg %s" "${readonly_pkgs[@]}") \
         "${tag_pkgs[@]}" \
         "$@"
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -75,7 +75,7 @@ func main() {
 
 type Args struct {
 	OutputFile   string
-	ExtraPkgs    []string // Always consider these as last-ditch possibilities for validations.
+	ReadOnlyPkgs []string // Always consider these as last-ditch possibilities for validations.
 	GoHeaderFile string
 	PrintDocs    bool
 	Lint         bool
@@ -85,7 +85,7 @@ type Args struct {
 func (args *Args) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&args.OutputFile, "output-file", "generated.validations.go",
 		"the name of the file to be generated")
-	fs.StringSliceVar(&args.ExtraPkgs, "extra-pkg", args.ExtraPkgs,
+	fs.StringSliceVar(&args.ReadOnlyPkgs, "readonly-pkg", args.ReadOnlyPkgs,
 		"the import path of a package whose validation can be used by generated code, but is not being generated for")
 	fs.StringVar(&args.GoHeaderFile, "go-header-file", "",
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
@@ -205,21 +205,21 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 	}
 
 	// Make sure explicit extra-packages are added.
-	var extraPkgs []string
-	for _, pkg := range args.ExtraPkgs {
+	var readOnlyPkgs []string
+	for _, pkg := range args.ReadOnlyPkgs {
 		// In case someone specifies an extra as a path into vendor, convert
 		// it to its "real" package path.
 		if i := strings.Index(pkg, "/vendor/"); i != -1 {
 			pkg = pkg[i+len("/vendor/"):]
 		}
-		extraPkgs = append(extraPkgs, pkg)
+		readOnlyPkgs = append(readOnlyPkgs, pkg)
 	}
-	if expanded, err := context.FindPackages(extraPkgs...); err != nil {
+	if expanded, err := context.FindPackages(readOnlyPkgs...); err != nil {
 		klog.Fatalf("cannot find extra packages: %v", err)
 	} else {
-		extraPkgs = expanded // now in fully canonical form
+		readOnlyPkgs = expanded // now in fully canonical form
 	}
-	for _, extra := range extraPkgs {
+	for _, extra := range readOnlyPkgs {
 		inputPkgs = append(inputPkgs, extra)
 		pkgToInput[extra] = extra
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -493,7 +493,7 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 			if elemNode := underlying.node.elem.node; elemNode == nil {
 				if !thisNode.typeValidations.OpaqueValType {
 					return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
 						fldPath, underlying.node.elem.childType)
 				}
@@ -524,7 +524,7 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 			if keyNode := underlying.node.key.node; keyNode == nil {
 				if !thisNode.typeValidations.OpaqueKeyType {
 					return nil, fmt.Errorf("%v: key type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachKey=+k8s:opaqueType to the field to skip validation",
 						fldPath, underlying.node.elem.childType)
 				}
@@ -554,7 +554,7 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 			if elemNode := underlying.node.elem.node; elemNode == nil {
 				if !thisNode.typeValidations.OpaqueValType {
 					return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
 						fldPath, underlying.node.elem.childType)
 				}
@@ -653,7 +653,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			if child.node == nil { // a non-included type
 				if !child.fieldValidations.OpaqueType {
 					return fmt.Errorf("%v: type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:opaqueType to the field to skip validation",
 						childPath, childType.String())
 				}
@@ -677,7 +677,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			if elemNode := child.node.elem.node; elemNode == nil {
 				if !child.fieldValidations.OpaqueValType {
 					return fmt.Errorf("%v: value type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
 						childPath, childType.Elem.String())
 				}
@@ -708,7 +708,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			if keyNode := child.node.key.node; keyNode == nil {
 				if !child.fieldValidations.OpaqueKeyType {
 					return fmt.Errorf("%v: key type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachKey=+k8s:opaqueType to the field to skip validation",
 						childPath, childType.Key.String())
 				}
@@ -738,7 +738,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			if elemNode := child.node.elem.node; elemNode == nil {
 				if !child.fieldValidations.OpaqueValType {
 					return fmt.Errorf("%v: value type %v is in a non-included package; "+
-						"either add this package to validation-gen's --extra-pkg flag, "+
+						"either add this package to validation-gen's --readonly-pkg flag, "+
 						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
 						childPath, childType.Elem.String())
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
@@ -50,7 +50,7 @@ func (opaqueTypeTagValidator) Docs() TagDoc {
 			"If a referenced type's package is not included in the generator's current " +
 			"flags, this tag must be set, or code generation will fail (preventing silent " +
 			"mistakes). If the validations should not be ignored, add the type's package " +
-			"to the generator using the --extra-pkg flag.",
+			"to the generator using the --readonly-pkg flag.",
 	}
 	return doc
 }


### PR DESCRIPTION
From offline discussion, --readonly-pkg is preferred to --extra-pkg in validation-gen

Will make a PR upstream for this once merged into the dev branch