### PR TITLE
test: fix make verify and add it to ci testing

### DIFF
--- a/.github/workflows/validation-gen-ci-test.yml
+++ b/.github/workflows/validation-gen-ci-test.yml
@@ -30,3 +30,6 @@ jobs:
         go test ./staging/src/k8s.io/apimachinery/pkg/util/...
         git diff --exit-code
 
+    - name: Run make verify
+      run: |
+        make verify

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/generate_docs.sh
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/generate_docs.sh
@@ -1,3 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
 # Directory where the script is located (staging/src/k8s.io/code-generator/validation-gen/)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package format
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package maxlength
 
 import (

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package minimum
 
 import (


### PR DESCRIPTION
This PR fixes "make verify" to pass in the feature branch (only boilerplate errors were needed to be fixed after latest rebase) and adds `make verify` to the CI tests

This way we can more easily ensure the feature branch can be upstreamed.  In doing so for 1.33, a number of deltas I encountered in my feature branch PRs vs upstream PRs were related to fixing `make verify` tests