### PR TITLE
Add API lint to verify scripts

### DIFF
--- a/hack/verify-api-lint.sh
+++ b/hack/verify-api-lint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs API lint tools.
+#
+# Usage: `hack/verify-api-lint.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+cd "${KUBE_ROOT}"
+
+LINT=true hack/update-codegen.sh

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+var ruleOptionalAndRequired = conflictingTagsRule(
+	"fields cannot be both optional and required",
+	"+k8s:optional", "+k8s:required")
+
+var ruleRequiredAndDefault = conflictingTagsRule(
+	"fields with default values are always optional",
+	"+k8s:required", "+default")
+
+var defaultLintRules = []lintRule{
+	ruleOptionalAndRequired,
+	ruleRequiredAndDefault,
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -78,7 +78,7 @@ type Args struct {
 	ReadOnlyPkgs []string // Always consider these as last-ditch possibilities for validations.
 	GoHeaderFile string
 	PrintDocs    bool
-	Lint         bool
+	LintOnly     bool
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -91,7 +91,7 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.BoolVar(&args.PrintDocs, "docs", false,
 		"print documentation for supported declarative validations, and then exit")
-	fs.BoolVar(&args.Lint, "lint", false,
+	fs.BoolVar(&args.LintOnly, "lint", false,
 		"only run linting checks, do not generate code")
 }
 


### PR DESCRIPTION
Results in errors like:
    
```
    $ ./hack/verify-api-lint.sh
    +++ [0317 09:00:04] Generating validation code for 69 targets
    F0317 09:00:05.637556 1049736 targets.go:363] lint failed:
      type k8s.io/api/core/v1.PodAffinityTerm:
        field LabelSelector: conflicting tags: {+k8s:optional, +k8s:required}: fields cannot be both optional and required
        field Namespaces: conflicting tags: {+default, +k8s:required}: fields with default values are always optional
    !!! [0317 09:00:05] Call tree:
    !!! [0317 09:00:05]  1: hack/update-codegen.sh:1132 codegen::validation(...)
```
