### PR TITLE
Fixes for bad handling of pointers and aliases in validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
@@ -24,11 +24,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// Immutable verifies that the specified value has not changed in the course of
-// an update operation.  It does nothing if the old value is not provided. If
-// the caller needs to compare types that are not trivially comparable, they
-// should use ImmutableNonComparable instead.
-func Immutable[T comparable](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue *T) field.ErrorList {
+// ImmutableByCompare verifies that the specified value has not changed in the
+// course of an update operation.  It does nothing if the old value is not
+// provided. If the caller needs to compare types that are not trivially
+// comparable, they should use ImmutableByReflect instead.
+//
+// Caution: structs with pointer fields satisfy comparable, but this function
+// will onlyu compare pointer values.  It does not do a "deep" comparison.
+func ImmutableByCompare[T comparable](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue *T) field.ErrorList {
 	if op.Type != operation.Update {
 		return nil
 	}
@@ -43,11 +46,11 @@ func Immutable[T comparable](_ context.Context, op operation.Operation, fldPath 
 	return nil
 }
 
-// ImmutableNonComparable verifies that the specified value has not changed in
+// ImmutableByReflect verifies that the specified value has not changed in
 // the course of an update operation.  It does nothing if the old value is not
-// provided. Unlike Immutable, this function can be used with types that are
+// provided. Unlike ImmutableByCompare, this function can be used with types that are
 // not directly comparable, at the cost of performance.
-func ImmutableNonComparable[T any](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue T) field.ErrorList {
+func ImmutableByReflect[T any](_ context.Context, op operation.Operation, fldPath *field.Path, value, oldValue T) field.ErrorList {
 	if op.Type != operation.Update {
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable_test.go
@@ -25,15 +25,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-type Struct struct {
+type StructComparable struct {
 	S string
 	I int
 	B bool
 }
 
-func TestImmutable(t *testing.T) {
-	structA := Struct{"abc", 123, true}
-	structB := Struct{"xyz", 456, false}
+func TestImmutableByCompare(t *testing.T) {
+	structA := StructComparable{"abc", 123, true}
+	structA2 := structA
+	structB := StructComparable{"xyz", 456, false}
 
 	for _, tc := range []struct {
 		name string
@@ -42,62 +43,194 @@ func TestImmutable(t *testing.T) {
 	}{{
 		name: "nil both values",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable[int](context.Background(), op, fld, nil, nil)
+			return ImmutableByCompare[int](context.Background(), op, fld, nil, nil)
 		},
 	}, {
 		name: "nil value",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, nil, ptr.To(123))
+			return ImmutableByCompare(context.Background(), op, fld, nil, ptr.To(123))
 		},
 		fail: true,
 	}, {
 		name: "nil oldValue",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(123), nil)
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(123), nil)
 		},
 		fail: true,
 	}, {
 		name: "int",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(123), ptr.To(123))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(123), ptr.To(123))
 		},
 	}, {
 		name: "int fail",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(123), ptr.To(456))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(123), ptr.To(456))
 		},
 		fail: true,
 	}, {
 		name: "string",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To("abc"), ptr.To("abc"))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To("abc"), ptr.To("abc"))
 		},
 	}, {
 		name: "string fail",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To("abc"), ptr.To("xyz"))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To("abc"), ptr.To("xyz"))
 		},
 		fail: true,
 	}, {
 		name: "bool",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(true), ptr.To(true))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(true), ptr.To(true))
 		},
 	}, {
 		name: "bool fail",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(true), ptr.To(false))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(true), ptr.To(false))
 		},
 		fail: true,
 	}, {
-		name: "struct",
+		name: "same struct",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(structA), ptr.To(structA))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(structA), ptr.To(structA))
+		},
+	}, {
+		name: "equal struct",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(structA), ptr.To(structA2))
 		},
 	}, {
 		name: "struct fail",
 		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
-			return Immutable(context.Background(), op, fld, ptr.To(structA), ptr.To(structB))
+			return ImmutableByCompare(context.Background(), op, fld, ptr.To(structA), ptr.To(structB))
+		},
+		fail: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.fn(operation.Operation{Type: operation.Create}, field.NewPath(""))
+			if len(errs) != 0 { // Create should always succeed
+				t.Errorf("case %q (create): expected success: %v", tc.name, errs)
+			}
+			errs = tc.fn(operation.Operation{Type: operation.Update}, field.NewPath(""))
+			if tc.fail && len(errs) == 0 {
+				t.Errorf("case %q (update): expected failure", tc.name)
+			} else if !tc.fail && len(errs) != 0 {
+				t.Errorf("case %q (update): expected success: %v", tc.name, errs)
+			}
+		})
+	}
+}
+
+type StructNonComparable struct {
+	S   string
+	SP  *string
+	I   int
+	IP  *int
+	B   bool
+	BP  *bool
+	SS  []string
+	MSS map[string]string
+}
+
+func TestImmutableByReflect(t *testing.T) {
+	structA := StructNonComparable{
+		S:   "abc",
+		SP:  ptr.To("abc"),
+		I:   123,
+		IP:  ptr.To(123),
+		B:   true,
+		BP:  ptr.To(true),
+		SS:  []string{"a", "b", "c"},
+		MSS: map[string]string{"a": "b", "c": "d"},
+	}
+
+	structA2 := structA
+	structA2.SP = ptr.To("abc")
+	structA2.IP = ptr.To(123)
+	structA2.BP = ptr.To(true)
+	structA2.SS = []string{"a", "b", "c"}
+	structA2.MSS = map[string]string{"a": "b", "c": "d"}
+
+	structB := StructNonComparable{
+		S:   "xyz",
+		SP:  ptr.To("xyz"),
+		I:   456,
+		IP:  ptr.To(456),
+		B:   false,
+		BP:  ptr.To(false),
+		SS:  []string{"x", "y", "z"},
+		MSS: map[string]string{"x": "X", "y": "Y"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		fn   func(operation.Operation, *field.Path) field.ErrorList
+		fail bool
+	}{{
+		name: "nil both values",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect[*int](context.Background(), op, fld, nil, nil)
+		},
+	}, {
+		name: "nil value",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, nil, ptr.To(123))
+		},
+		fail: true,
+	}, {
+		name: "nil oldValue",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(123), nil)
+		},
+		fail: true,
+	}, {
+		name: "int",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(123), ptr.To(123))
+		},
+	}, {
+		name: "int fail",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(123), ptr.To(456))
+		},
+		fail: true,
+	}, {
+		name: "string",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To("abc"), ptr.To("abc"))
+		},
+	}, {
+		name: "string fail",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To("abc"), ptr.To("xyz"))
+		},
+		fail: true,
+	}, {
+		name: "bool",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(true), ptr.To(true))
+		},
+	}, {
+		name: "bool fail",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(true), ptr.To(false))
+		},
+		fail: true,
+	}, {
+		name: "same struct",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(structA), ptr.To(structA))
+		},
+	}, {
+		name: "equal struct",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(structA), ptr.To(structA2))
+		},
+	}, {
+		name: "struct fail",
+		fn: func(op operation.Operation, fld *field.Path) field.ErrorList {
+			return ImmutableByReflect(context.Background(), op, fld, ptr.To(structA), ptr.To(structB))
 		},
 		fail: true,
 	}} {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -21,10 +21,15 @@ var ruleOptionalAndRequired = conflictingTagsRule(
 	"+k8s:optional", "+k8s:required")
 
 var ruleRequiredAndDefault = conflictingTagsRule(
-	"fields with default values are always optional",
+	"fields with default values must be optional",
 	"+k8s:required", "+default")
+
+var ruleUnionMemberAndOptional = dependentTagsRule(
+	"fields which are union members must be optional",
+	"+k8s:unionMember", "+k8s:optional")
 
 var defaultLintRules = []lintRule{
 	ruleOptionalAndRequired,
 	ruleRequiredAndDefault,
+	ruleUnionMemberAndOptional,
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc.go
@@ -36,6 +36,30 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.StringPtrField"
 	StringPtrField *string `json:"stringPtrField"`
 
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.StringTypedefField"
+	StringTypedefField StringType `json:"stringTypedefField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.StringTypedefPtrField"
+	StringTypedefPtrField *StringType `json:"stringTypedefPtrField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.IntField"
+	IntField int `json:"intField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.IntPtrField"
+	IntPtrField *int `json:"intPtrField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.IntTypedefField"
+	IntTypedefField IntType `json:"intTypedefField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.IntTypedefPtrField"
+	IntTypedefPtrField *IntType `json:"intTypedefPtrField"`
+
 	// non-pointer struct fields cannot be forbidden
 
 	// +k8s:forbidden
@@ -50,6 +74,12 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
 }
+
+// +k8s:validateFalse="type StringType"
+type StringType string
+
+// +k8s:validateFalse="type IntType"
+type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc.go
@@ -71,8 +71,16 @@ type Struct struct {
 	SliceField []string `json:"sliceField"`
 
 	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.SliceTypedefField"
+	SliceTypedefField SliceType `json:"sliceTypedefField"`
+
+	// +k8s:forbidden
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
+
+	// +k8s:forbidden
+	// +k8s:validateFalse="field Struct.MapTypedefField"
+	MapTypedefField MapType `json:"mapTypedefField"`
 }
 
 // +k8s:validateFalse="type StringType"
@@ -83,3 +91,9 @@ type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}
+
+// +k8s:validateFalse="type SliceType"
+type SliceType []string
+
+// +k8s:validateFalse="type MapType"
+type MapType map[string]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
@@ -30,16 +30,28 @@ func Test(t *testing.T) {
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		StringField:         "abc",
-		StringPtrField:      ptr.To("xyz"),
-		OtherStructPtrField: &OtherStruct{},
-		SliceField:          []string{"a", "b"},
-		MapField:            map[string]string{"a": "b", "c": "d"},
+		StringField:           "abc",
+		StringPtrField:        ptr.To("xyz"),
+		StringTypedefField:    StringType("abc"),
+		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		IntField:              123,
+		IntPtrField:           ptr.To(456),
+		IntTypedefField:       IntType(123),
+		IntTypedefPtrField:    ptr.To(IntType(456)),
+		OtherStructPtrField:   &OtherStruct{},
+		SliceField:            []string{"a", "b"},
+		MapField:              map[string]string{"a": "b", "c": "d"},
 	}).ExpectRegexpsByPath(map[string][]string{
-		"stringField":         []string{"Forbidden"},
-		"stringPtrField":      []string{"Forbidden"},
-		"otherStructPtrField": []string{"Forbidden"},
-		"sliceField":          []string{"Forbidden"},
-		"mapField":            []string{"Forbidden"},
+		"stringField":           []string{"Forbidden"},
+		"stringPtrField":        []string{"Forbidden"},
+		"stringTypedefField":    []string{"Forbidden"},
+		"stringTypedefPtrField": []string{"Forbidden"},
+		"intField":              []string{"Forbidden"},
+		"intPtrField":           []string{"Forbidden"},
+		"intTypedefField":       []string{"Forbidden"},
+		"intTypedefPtrField":    []string{"Forbidden"},
+		"otherStructPtrField":   []string{"Forbidden"},
+		"sliceField":            []string{"Forbidden"},
+		"mapField":              []string{"Forbidden"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
@@ -40,7 +40,9 @@ func Test(t *testing.T) {
 		IntTypedefPtrField:    ptr.To(IntType(456)),
 		OtherStructPtrField:   &OtherStruct{},
 		SliceField:            []string{"a", "b"},
+		SliceTypedefField:     SliceType([]string{"a", "b"}),
 		MapField:              map[string]string{"a": "b", "c": "d"},
+		MapTypedefField:       MapType(map[string]string{"a": "b", "c": "d"}),
 	}).ExpectRegexpsByPath(map[string][]string{
 		"stringField":           []string{"Forbidden"},
 		"stringPtrField":        []string{"Forbidden"},
@@ -52,6 +54,8 @@ func Test(t *testing.T) {
 		"intTypedefPtrField":    []string{"Forbidden"},
 		"otherStructPtrField":   []string{"Forbidden"},
 		"sliceField":            []string{"Forbidden"},
+		"sliceTypedefField":     []string{"Forbidden"},
 		"mapField":              []string{"Forbidden"},
+		"mapTypedefField":       []string{"Forbidden"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
@@ -42,9 +42,23 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
+func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+	// type IntType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type IntType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+	// type StringType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
@@ -79,6 +93,94 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
+
+	// field Struct.StringTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.ForbiddenValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefField"), &obj.StringTypedefField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return &oldObj.StringTypedefField }))...)
+
+	// field Struct.StringTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefPtrField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefPtrField"), obj.StringTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return oldObj.StringTypedefPtrField }))...)
+
+	// field Struct.IntField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.ForbiddenValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntField")...)
+			return
+		}(fldPath.Child("intField"), &obj.IntField, safe.Field(oldObj, func(oldObj *Struct) *int { return &oldObj.IntField }))...)
+
+	// field Struct.IntPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntPtrField")...)
+			return
+		}(fldPath.Child("intPtrField"), obj.IntPtrField, safe.Field(oldObj, func(oldObj *Struct) *int { return oldObj.IntPtrField }))...)
+
+	// field Struct.IntTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.ForbiddenValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefField"), &obj.IntTypedefField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return &oldObj.IntTypedefField }))...)
+
+	// field Struct.IntTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.ForbiddenPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefPtrField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefPtrField"), obj.IntTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return oldObj.IntTypedefPtrField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
@@ -49,9 +49,23 @@ func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *fiel
 	return errs
 }
 
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+	// type MapType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+	// type SliceType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
 
 	return errs
 }
@@ -211,6 +225,21 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
+	// field Struct.SliceTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+			if e := validate.ForbiddenSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceTypedefField")...)
+			errs = append(errs, Validate_SliceType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("sliceTypedefField"), obj.SliceTypedefField, safe.Field(oldObj, func(oldObj *Struct) SliceType { return oldObj.SliceTypedefField }))...)
+
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
@@ -224,6 +253,21 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
+
+	// field Struct.MapTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+			if e := validate.ForbiddenMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) MapType { return oldObj.MapTypedefField }))...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc.go
@@ -57,7 +57,8 @@ type Struct struct {
 }
 
 type ComparableStruct struct {
-	StringField string `json:"stringField"`
+	StringField    string  `json:"stringField"`
+	StringPtrField *string `json:"stringPtrField"`
 }
 
 type NonComparableStruct struct {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
@@ -38,6 +38,13 @@ func Test(t *testing.T) {
 		ImmutableField:              "fff",
 		ImmutablePtrField:           ptr.To(ImmutableType("fff")),
 	}
+
+	structA2 := structA // dup of A but with different pointer values
+	structA2.StringPtrField = ptr.To(*structA2.StringPtrField)
+	structA2.StructPtrField = ptr.To(*structA2.StructPtrField)
+	structA2.NonComparableStructPtrField = ptr.To(*structA2.NonComparableStructPtrField)
+	structA2.ImmutablePtrField = ptr.To(*structA2.ImmutablePtrField)
+
 	structB := Struct{
 		StringField:                 "uuu",
 		StringPtrField:              ptr.To("uuu"),
@@ -52,6 +59,8 @@ func Test(t *testing.T) {
 	}
 
 	st.Value(&structA).OldValue(&structA).ExpectValid()
+	st.Value(&structA).OldValue(&structA2).ExpectValid()
+	st.Value(&structA2).OldValue(&structA).ExpectValid()
 
 	st.Value(&structA).OldValue(&structB).ExpectInvalid(
 		field.Forbidden(field.NewPath("stringField"), "field is immutable"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
@@ -29,8 +29,8 @@ func Test(t *testing.T) {
 	structA := Struct{
 		StringField:                 "aaa",
 		StringPtrField:              ptr.To("aaa"),
-		StructField:                 ComparableStruct{"bbb"},
-		StructPtrField:              ptr.To(ComparableStruct{"bbb"}),
+		StructField:                 ComparableStruct{"bbb", ptr.To("BBB")},
+		StructPtrField:              ptr.To(ComparableStruct{"bbb", ptr.To("BBB")}),
 		NonComparableStructField:    NonComparableStruct{[]string{"ccc"}},
 		NonComparableStructPtrField: ptr.To(NonComparableStruct{[]string{"ccc"}}),
 		SliceField:                  []string{"ddd"},
@@ -41,15 +41,17 @@ func Test(t *testing.T) {
 
 	structA2 := structA // dup of A but with different pointer values
 	structA2.StringPtrField = ptr.To(*structA2.StringPtrField)
+	structA2.StructField.StringPtrField = ptr.To("BBB")
 	structA2.StructPtrField = ptr.To(*structA2.StructPtrField)
+	structA2.StructPtrField.StringPtrField = ptr.To("BBB")
 	structA2.NonComparableStructPtrField = ptr.To(*structA2.NonComparableStructPtrField)
 	structA2.ImmutablePtrField = ptr.To(*structA2.ImmutablePtrField)
 
 	structB := Struct{
 		StringField:                 "uuu",
 		StringPtrField:              ptr.To("uuu"),
-		StructField:                 ComparableStruct{"vvv"},
-		StructPtrField:              ptr.To(ComparableStruct{"vvv"}),
+		StructField:                 ComparableStruct{"vvv", ptr.To("VVV")},
+		StructPtrField:              ptr.To(ComparableStruct{"vvv", ptr.To("VVV")}),
 		NonComparableStructField:    NonComparableStruct{[]string{"www"}},
 		NonComparableStructPtrField: ptr.To(NonComparableStruct{[]string{"www"}}),
 		SliceField:                  []string{"xxx"},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
@@ -44,7 +44,7 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 
 func Validate_ImmutableType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ImmutableType) (errs field.ErrorList) {
 	// type ImmutableType
-	errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+	errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 
 	return errs
 }
@@ -55,56 +55,56 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.StringField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("stringField"), &obj.StringField, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.StringField }))...)
 
 	// field Struct.StringPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
 
 	// field Struct.StructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("structField"), &obj.StructField, safe.Field(oldObj, func(oldObj *Struct) *ComparableStruct { return &oldObj.StructField }))...)
 
 	// field Struct.StructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *ComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("structPtrField"), obj.StructPtrField, safe.Field(oldObj, func(oldObj *Struct) *ComparableStruct { return oldObj.StructPtrField }))...)
 
 	// field Struct.NonComparableStructField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *NonComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("noncomparableStructField"), &obj.NonComparableStructField, safe.Field(oldObj, func(oldObj *Struct) *NonComparableStruct { return &oldObj.NonComparableStructField }))...)
 
 	// field Struct.NonComparableStructPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *NonComparableStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("noncomparableStructPtrField"), obj.NonComparableStructPtrField, safe.Field(oldObj, func(oldObj *Struct) *NonComparableStruct { return oldObj.NonComparableStructPtrField }))...)
 
 	// field Struct.SliceField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
-			errs = append(errs, validate.ImmutableNonComparable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByReflect(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -50,7 +50,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
-			}, validate.Immutable)...)
+			}, validate.ImmutableByReflect)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
@@ -59,7 +59,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
-			}, validate.Immutable)...)
+			}, validate.ImmutableByReflect)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -48,14 +48,14 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.ListField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByReflect)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
 	// field Struct.ListTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []OtherTypedefStruct) (errs field.ErrorList) {
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.Immutable)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByReflect)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc.go
@@ -30,20 +30,38 @@ type Struct struct {
 	// +k8s:maxLength=0
 	Max0Field string `json:"max0Field"`
 
+	// +k8s:maxLength=0
+	Max0PtrField *string `json:"max0PtrField"`
+
 	// +k8s:maxLength=10
 	Max10Field string `json:"max10Field"`
+
+	// +k8s:maxLength=10
+	Max10PtrField *string `json:"max10PtrField"`
 
 	// +k8s:maxLength=0
 	Max0UnvalidatedTypedefField UnvalidatedStringType `json:"max0UnvalidatedTypedefField"`
 
+	// +k8s:maxLength=0
+	Max0UnvalidatedTypedefPtrField *UnvalidatedStringType `json:"max0UnvalidatedTypedefPtrField"`
+
 	// +k8s:maxLength=10
 	Max10UnvalidatedTypedefField UnvalidatedStringType `json:"max10UnvalidatedTypedefField"`
+
+	// +k8s:maxLength=10
+	Max10UnvalidatedTypedefPtrField *UnvalidatedStringType `json:"max10UnvalidatedTypedefPtrField"`
 
 	// Note: no validation here
 	Max0ValidatedTypedefField Max0Type `json:"max0ValidatedTypedefField"`
 
 	// Note: no validation here
+	Max0ValidatedTypedefPtrField *Max0Type `json:"max0ValidatedTypedefPtrField"`
+
+	// Note: no validation here
 	Max10ValidatedTypedefField Max10Type `json:"max10ValidatedTypedefField"`
+
+	// Note: no validation here
+	Max10ValidatedTypedefPtrField *Max10Type `json:"max10ValidatedTypedefPtrField"`
 }
 
 // Note: no validation here

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
@@ -19,6 +19,8 @@ package maxlength
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -29,36 +31,57 @@ func Test(t *testing.T) {
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		Max10Field:                   strings.Repeat("x", 1),
-		Max10UnvalidatedTypedefField: UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max10ValidatedTypedefField:   Max10Type(strings.Repeat("x", 1)),
+		Max10Field:                      strings.Repeat("x", 1),
+		Max10PtrField:                   ptr.To(strings.Repeat("x", 1)),
+		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 1)),
+		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 1)),
+		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 1))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		Max10Field:                   strings.Repeat("x", 9),
-		Max10UnvalidatedTypedefField: UnvalidatedStringType(strings.Repeat("x", 9)),
-		Max10ValidatedTypedefField:   Max10Type(strings.Repeat("x", 9)),
+		Max10Field:                      strings.Repeat("x", 9),
+		Max10PtrField:                   ptr.To(strings.Repeat("x", 9)),
+		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 9)),
+		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 9)),
+		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 9))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		Max10Field:                   strings.Repeat("x", 10),
-		Max10UnvalidatedTypedefField: UnvalidatedStringType(strings.Repeat("x", 10)),
-		Max10ValidatedTypedefField:   Max10Type(strings.Repeat("x", 10)),
+		Max10Field:                      strings.Repeat("x", 10),
+		Max10PtrField:                   ptr.To(strings.Repeat("x", 10)),
+		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 10)),
+		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 10))),
+		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 10)),
+		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 10))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		Max0Field:                    strings.Repeat("x", 1),
-		Max10Field:                   strings.Repeat("x", 11),
-		Max0UnvalidatedTypedefField:  UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max10UnvalidatedTypedefField: UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max0ValidatedTypedefField:    Max0Type(strings.Repeat("x", 1)),
-		Max10ValidatedTypedefField:   Max10Type(strings.Repeat("x", 11)),
+		Max0Field:                       strings.Repeat("x", 1),
+		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max10Field:                      strings.Repeat("x", 11),
+		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
+		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
+		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
+		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
+		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
 	}).ExpectRegexpsByPath(map[string][]string{
-		"max0Field":                    []string{`Invalid value:.*must be no more than 0 bytes`},
-		"max10Field":                   []string{`Invalid value:.*must be no more than 10 bytes`},
-		"max0UnvalidatedTypedefField":  []string{`Invalid value:.*must be no more than 0 bytes`},
-		"max10UnvalidatedTypedefField": []string{`Invalid value:.*must be no more than 10 bytes`},
-		"max0ValidatedTypedefField":    []string{`Invalid value:.*must be no more than 0 bytes`},
-		"max10ValidatedTypedefField":   []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max0Field":                       []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max0PtrField":                    []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max10Field":                      []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max10PtrField":                   []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max0UnvalidatedTypedefField":     []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max0UnvalidatedTypedefPtrField":  []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max10UnvalidatedTypedefField":    []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max10UnvalidatedTypedefPtrField": []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max0ValidatedTypedefField":       []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max0ValidatedTypedefPtrField":    []string{`Invalid value:.*must be no more than 0 bytes`},
+		"max10ValidatedTypedefField":      []string{`Invalid value:.*must be no more than 10 bytes`},
+		"max10ValidatedTypedefPtrField":   []string{`Invalid value:.*must be no more than 10 bytes`},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/zz_generated.validations.go
@@ -66,12 +66,26 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("max0Field"), &obj.Max0Field, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.Max0Field }))...)
 
+	// field Struct.Max0PtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 0)...)
+			return
+		}(fldPath.Child("max0PtrField"), obj.Max0PtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.Max0PtrField }))...)
+
 	// field Struct.Max10Field
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
 			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
 			return
 		}(fldPath.Child("max10Field"), &obj.Max10Field, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.Max10Field }))...)
+
+	// field Struct.Max10PtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
+			return
+		}(fldPath.Child("max10PtrField"), obj.Max10PtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.Max10PtrField }))...)
 
 	// field Struct.Max0UnvalidatedTypedefField
 	errs = append(errs,
@@ -80,12 +94,26 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("max0UnvalidatedTypedefField"), &obj.Max0UnvalidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return &oldObj.Max0UnvalidatedTypedefField }))...)
 
+	// field Struct.Max0UnvalidatedTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 0)...)
+			return
+		}(fldPath.Child("max0UnvalidatedTypedefPtrField"), obj.Max0UnvalidatedTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return oldObj.Max0UnvalidatedTypedefPtrField }))...)
+
 	// field Struct.Max10UnvalidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
 			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
 			return
 		}(fldPath.Child("max10UnvalidatedTypedefField"), &obj.Max10UnvalidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return &oldObj.Max10UnvalidatedTypedefField }))...)
+
+	// field Struct.Max10UnvalidatedTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *UnvalidatedStringType) (errs field.ErrorList) {
+			errs = append(errs, validate.MaxLength(ctx, op, fldPath, obj, oldObj, 10)...)
+			return
+		}(fldPath.Child("max10UnvalidatedTypedefPtrField"), obj.Max10UnvalidatedTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *UnvalidatedStringType { return oldObj.Max10UnvalidatedTypedefPtrField }))...)
 
 	// field Struct.Max0ValidatedTypedefField
 	errs = append(errs,
@@ -94,12 +122,26 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("max0ValidatedTypedefField"), &obj.Max0ValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *Max0Type { return &oldObj.Max0ValidatedTypedefField }))...)
 
+	// field Struct.Max0ValidatedTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *Max0Type) (errs field.ErrorList) {
+			errs = append(errs, Validate_Max0Type(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("max0ValidatedTypedefPtrField"), obj.Max0ValidatedTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *Max0Type { return oldObj.Max0ValidatedTypedefPtrField }))...)
+
 	// field Struct.Max10ValidatedTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *Max10Type) (errs field.ErrorList) {
 			errs = append(errs, Validate_Max10Type(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("max10ValidatedTypedefField"), &obj.Max10ValidatedTypedefField, safe.Field(oldObj, func(oldObj *Struct) *Max10Type { return &oldObj.Max10ValidatedTypedefField }))...)
+
+	// field Struct.Max10ValidatedTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *Max10Type) (errs field.ErrorList) {
+			errs = append(errs, Validate_Max10Type(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("max10ValidatedTypedefPtrField"), obj.Max10ValidatedTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *Max10Type { return oldObj.Max10ValidatedTypedefPtrField }))...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
@@ -70,8 +70,16 @@ type Struct struct {
 	SliceField []string `json:"sliceField"`
 
 	// +k8s:optional
+	// +k8s:validateFalse="field Struct.SliceTypedefField"
+	SliceTypedefField SliceType `json:"sliceTypedefField"`
+
+	// +k8s:optional
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.MapTypedefField"
+	MapTypedefField MapType `json:"mapTypedefField"`
 }
 
 // +k8s:validateFalse="type StringType"
@@ -82,3 +90,9 @@ type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}
+
+// +k8s:validateFalse="type SliceType"
+type SliceType []string
+
+// +k8s:validateFalse="type MapType"
+type MapType map[string]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc.go
@@ -35,6 +35,30 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.StringPtrField"
 	StringPtrField *string `json:"stringPtrField"`
 
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.StringTypedefField"
+	StringTypedefField StringType `json:"stringTypedefField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.StringTypedefPtrField"
+	StringTypedefPtrField *StringType `json:"stringTypedefPtrField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.IntField"
+	IntField int `json:"intField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.IntPtrField"
+	IntPtrField *int `json:"intPtrField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.IntTypedefField"
+	IntTypedefField IntType `json:"intTypedefField"`
+
+	// +k8s:optional
+	// +k8s:validateFalse="field Struct.IntTypedefPtrField"
+	IntTypedefPtrField *IntType `json:"intTypedefPtrField"`
+
 	// non-pointer struct fields cannot be optional
 
 	// +k8s:optional
@@ -49,6 +73,12 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
 }
+
+// +k8s:validateFalse="type StringType"
+type StringType string
+
+// +k8s:validateFalse="type IntType"
+type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
@@ -40,7 +40,9 @@ func Test(t *testing.T) {
 		IntTypedefPtrField:    ptr.To(IntType(456)),
 		OtherStructPtrField:   &OtherStruct{},
 		SliceField:            []string{"a", "b"},
+		SliceTypedefField:     SliceType([]string{"a", "b"}),
 		MapField:              map[string]string{"a": "b", "c": "d"},
+		MapTypedefField:       MapType(map[string]string{"a": "b", "c": "d"}),
 	}).ExpectValidateFalseByPath(map[string][]string{
 		"stringField":           {"field Struct.StringField"},
 		"stringPtrField":        {"field Struct.StringPtrField"},
@@ -52,6 +54,8 @@ func Test(t *testing.T) {
 		"intTypedefPtrField":    {"field Struct.IntTypedefPtrField", "type IntType"},
 		"otherStructPtrField":   {"type OtherStruct", "field Struct.OtherStructPtrField"},
 		"sliceField":            {"field Struct.SliceField"},
+		"sliceTypedefField":     {"field Struct.SliceTypedefField", "type SliceType"},
 		"mapField":              {"field Struct.MapField"},
+		"mapTypedefField":       {"field Struct.MapTypedefField", "type MapType"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
@@ -30,16 +30,28 @@ func Test(t *testing.T) {
 	}).ExpectValid()
 
 	st.Value(&Struct{
-		StringField:         "abc",
-		StringPtrField:      ptr.To("xyz"),
-		OtherStructPtrField: &OtherStruct{},
-		SliceField:          []string{"a", "b"},
-		MapField:            map[string]string{"a": "b", "c": "d"},
+		StringField:           "abc",
+		StringPtrField:        ptr.To("xyz"),
+		StringTypedefField:    StringType("abc"),
+		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		IntField:              123,
+		IntPtrField:           ptr.To(456),
+		IntTypedefField:       IntType(123),
+		IntTypedefPtrField:    ptr.To(IntType(456)),
+		OtherStructPtrField:   &OtherStruct{},
+		SliceField:            []string{"a", "b"},
+		MapField:              map[string]string{"a": "b", "c": "d"},
 	}).ExpectValidateFalseByPath(map[string][]string{
-		"stringField":         {"field Struct.StringField"},
-		"stringPtrField":      {"field Struct.StringPtrField"},
-		"otherStructPtrField": {"type OtherStruct", "field Struct.OtherStructPtrField"},
-		"sliceField":          {"field Struct.SliceField"},
-		"mapField":            {"field Struct.MapField"},
+		"stringField":           {"field Struct.StringField"},
+		"stringPtrField":        {"field Struct.StringPtrField"},
+		"stringTypedefField":    {"field Struct.StringTypedefField", "type StringType"},
+		"stringTypedefPtrField": {"field Struct.StringTypedefPtrField", "type StringType"},
+		"intField":              {"field Struct.IntField"},
+		"intPtrField":           {"field Struct.IntPtrField"},
+		"intTypedefField":       {"field Struct.IntTypedefField", "type IntType"},
+		"intTypedefPtrField":    {"field Struct.IntTypedefPtrField", "type IntType"},
+		"otherStructPtrField":   {"type OtherStruct", "field Struct.OtherStructPtrField"},
+		"sliceField":            {"field Struct.SliceField"},
+		"mapField":              {"field Struct.MapField"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
@@ -42,9 +42,23 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
+func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+	// type IntType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type IntType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+	// type StringType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
@@ -71,6 +85,70 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
+
+	// field Struct.StringTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefField"), &obj.StringTypedefField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return &oldObj.StringTypedefField }))...)
+
+	// field Struct.StringTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefPtrField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefPtrField"), obj.StringTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return oldObj.StringTypedefPtrField }))...)
+
+	// field Struct.IntField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntField")...)
+			return
+		}(fldPath.Child("intField"), &obj.IntField, safe.Field(oldObj, func(oldObj *Struct) *int { return &oldObj.IntField }))...)
+
+	// field Struct.IntPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntPtrField")...)
+			return
+		}(fldPath.Child("intPtrField"), obj.IntPtrField, safe.Field(oldObj, func(oldObj *Struct) *int { return oldObj.IntPtrField }))...)
+
+	// field Struct.IntTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefField"), &obj.IntTypedefField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return &oldObj.IntTypedefField }))...)
+
+	// field Struct.IntTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefPtrField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefPtrField"), obj.IntTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return oldObj.IntTypedefPtrField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
@@ -49,9 +49,23 @@ func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *fiel
 	return errs
 }
 
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+	// type MapType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+	// type SliceType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
 
 	return errs
 }
@@ -171,6 +185,17 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
+	// field Struct.SliceTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceTypedefField")...)
+			errs = append(errs, Validate_SliceType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("sliceTypedefField"), obj.SliceTypedefField, safe.Field(oldObj, func(oldObj *Struct) SliceType { return oldObj.SliceTypedefField }))...)
+
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
@@ -180,6 +205,17 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
+
+	// field Struct.MapTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) MapType { return oldObj.MapTypedefField }))...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc.go
@@ -70,8 +70,16 @@ type Struct struct {
 	SliceField []string `json:"sliceField"`
 
 	// +k8s:required
+	// +k8s:validateFalse="field Struct.SliceTypedefField"
+	SliceTypedefField SliceType `json:"sliceTypedefField"`
+
+	// +k8s:required
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.MapTypedefField"
+	MapTypedefField MapType `json:"mapTypedefField"`
 }
 
 // +k8s:validateFalse="type StringType"
@@ -82,3 +90,9 @@ type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}
+
+// +k8s:validateFalse="type SliceType"
+type SliceType []string
+
+// +k8s:validateFalse="type MapType"
+type MapType map[string]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc.go
@@ -35,6 +35,30 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.StringPtrField"
 	StringPtrField *string `json:"stringPtrField"`
 
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.StringTypedefField"
+	StringTypedefField StringType `json:"stringTypedefField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.StringTypedefPtrField"
+	StringTypedefPtrField *StringType `json:"stringTypedefPtrField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.IntField"
+	IntField int `json:"intField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.IntPtrField"
+	IntPtrField *int `json:"intPtrField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.IntTypedefField"
+	IntTypedefField IntType `json:"intTypedefField"`
+
+	// +k8s:required
+	// +k8s:validateFalse="field Struct.IntTypedefPtrField"
+	IntTypedefPtrField *IntType `json:"intTypedefPtrField"`
+
 	// non-pointer struct fields cannot be required
 
 	// +k8s:required
@@ -49,6 +73,12 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.MapField"
 	MapField map[string]string `json:"mapField"`
 }
+
+// +k8s:validateFalse="type StringType"
+type StringType string
+
+// +k8s:validateFalse="type IntType"
+type IntType int
 
 // +k8s:validateFalse="type OtherStruct"
 type OtherStruct struct{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
@@ -38,7 +38,9 @@ func Test(t *testing.T) {
 		"intTypedefPtrField":    []string{"Required value"},
 		"otherStructPtrField":   []string{"Required value"},
 		"sliceField":            []string{"Required value"},
+		"sliceTypedefField":     []string{"Required value"},
 		"mapField":              []string{"Required value"},
+		"mapTypedefField":       []string{"Required value"},
 	})
 
 	st.Value(&Struct{
@@ -47,7 +49,9 @@ func Test(t *testing.T) {
 		IntPtrField:           ptr.To(0),              // satisfies required
 		IntTypedefPtrField:    ptr.To(IntType(0)),     // satisfies required
 		SliceField:            []string{},             // does not satisfy required
+		SliceTypedefField:     []string{},             // does not satisfy required
 		MapField:              map[string]string{},    // does not satisfy required
+		MapTypedefField:       map[string]string{},    // does not satisfy required
 	}).ExpectRegexpsByPath(map[string][]string{
 		"stringField":           []string{"Required value"},
 		"stringPtrField":        []string{"field Struct.StringPtrField"},
@@ -59,7 +63,9 @@ func Test(t *testing.T) {
 		"intTypedefPtrField":    []string{"field Struct.IntTypedefPtrField", "type IntType"},
 		"otherStructPtrField":   []string{"Required value"},
 		"sliceField":            []string{"Required value"},
+		"sliceTypedefField":     []string{"Required value"},
 		"mapField":              []string{"Required value"},
+		"mapTypedefField":       []string{"Required value"},
 	})
 
 	st.Value(&Struct{
@@ -73,7 +79,9 @@ func Test(t *testing.T) {
 		IntTypedefPtrField:    ptr.To(IntType(456)),
 		OtherStructPtrField:   &OtherStruct{},
 		SliceField:            []string{"a", "b"},
+		SliceTypedefField:     SliceType([]string{"a", "b"}),
 		MapField:              map[string]string{"a": "b", "c": "d"},
+		MapTypedefField:       MapType(map[string]string{"a": "b", "c": "d"}),
 	}).ExpectRegexpsByPath(map[string][]string{
 		"stringField":           []string{"field Struct.StringField"},
 		"stringPtrField":        []string{"field Struct.StringPtrField"},
@@ -85,6 +93,8 @@ func Test(t *testing.T) {
 		"intTypedefPtrField":    []string{"field Struct.IntTypedefPtrField", "type IntType"},
 		"otherStructPtrField":   []string{"field Struct.OtherStructPtrField", "type OtherStruct"},
 		"sliceField":            []string{"field Struct.SliceField"},
+		"sliceTypedefField":     []string{"field Struct.SliceTypedefField", "type SliceType"},
 		"mapField":              []string{"field Struct.MapField"},
+		"mapTypedefField":       []string{"field Struct.MapTypedefField", "type MapType"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
@@ -28,39 +28,63 @@ func Test(t *testing.T) {
 	st.Value(&Struct{
 		// All zero-values.
 	}).ExpectRegexpsByPath(map[string][]string{
-		"stringField":         []string{"Required value"},
-		"stringPtrField":      []string{"Required value"},
-		"otherStructPtrField": []string{"Required value"},
-		"sliceField":          []string{"Required value"},
-		"mapField":            []string{"Required value"},
+		"stringField":           []string{"Required value"},
+		"stringPtrField":        []string{"Required value"},
+		"stringTypedefField":    []string{"Required value"},
+		"stringTypedefPtrField": []string{"Required value"},
+		"intField":              []string{"Required value"},
+		"intPtrField":           []string{"Required value"},
+		"intTypedefField":       []string{"Required value"},
+		"intTypedefPtrField":    []string{"Required value"},
+		"otherStructPtrField":   []string{"Required value"},
+		"sliceField":            []string{"Required value"},
+		"mapField":              []string{"Required value"},
 	})
 
 	st.Value(&Struct{
-		StringPtrField: ptr.To(""),          // satisfies required
-		SliceField:     []string{},          // does not satisfy required
-		MapField:       map[string]string{}, // does not satisfy required
+		StringPtrField:        ptr.To(""),             // satisfies required
+		StringTypedefPtrField: ptr.To(StringType("")), // satisfies required
+		IntPtrField:           ptr.To(0),              // satisfies required
+		IntTypedefPtrField:    ptr.To(IntType(0)),     // satisfies required
+		SliceField:            []string{},             // does not satisfy required
+		MapField:              map[string]string{},    // does not satisfy required
 	}).ExpectRegexpsByPath(map[string][]string{
-		"stringField":         []string{"Required value"},
-		"stringPtrField":      []string{"forced failure: field Struct.StringPtrField"},
-		"otherStructPtrField": []string{"Required value"},
-		"sliceField":          []string{"Required value"},
-		"mapField":            []string{"Required value"},
+		"stringField":           []string{"Required value"},
+		"stringPtrField":        []string{"field Struct.StringPtrField"},
+		"stringTypedefField":    []string{"Required value"},
+		"stringTypedefPtrField": []string{"field Struct.StringTypedefPtrField", "type StringType"},
+		"intField":              []string{"Required value"},
+		"intPtrField":           []string{"field Struct.IntPtrField"},
+		"intTypedefField":       []string{"Required value"},
+		"intTypedefPtrField":    []string{"field Struct.IntTypedefPtrField", "type IntType"},
+		"otherStructPtrField":   []string{"Required value"},
+		"sliceField":            []string{"Required value"},
+		"mapField":              []string{"Required value"},
 	})
 
 	st.Value(&Struct{
-		StringField:         "abc",
-		StringPtrField:      ptr.To("xyz"),
-		OtherStructPtrField: &OtherStruct{},
-		SliceField:          []string{"a", "b"},
-		MapField:            map[string]string{"a": "b", "c": "d"},
+		StringField:           "abc",
+		StringPtrField:        ptr.To("xyz"),
+		StringTypedefField:    StringType("abc"),
+		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		IntField:              123,
+		IntPtrField:           ptr.To(456),
+		IntTypedefField:       IntType(123),
+		IntTypedefPtrField:    ptr.To(IntType(456)),
+		OtherStructPtrField:   &OtherStruct{},
+		SliceField:            []string{"a", "b"},
+		MapField:              map[string]string{"a": "b", "c": "d"},
 	}).ExpectRegexpsByPath(map[string][]string{
-		"stringField":    []string{"forced failure: field Struct.StringField"},
-		"stringPtrField": []string{"forced failure: field Struct.StringPtrField"},
-		"otherStructPtrField": []string{
-			"forced failure: type OtherStruct",
-			"forced failure: field Struct.OtherStructPtrField",
-		},
-		"sliceField": []string{"forced failure: field Struct.SliceField"},
-		"mapField":   []string{"forced failure: field Struct.MapField"},
+		"stringField":           []string{"field Struct.StringField"},
+		"stringPtrField":        []string{"field Struct.StringPtrField"},
+		"stringTypedefField":    []string{"field Struct.StringTypedefField", "type StringType"},
+		"stringTypedefPtrField": []string{"field Struct.StringTypedefPtrField", "type StringType"},
+		"intField":              []string{"field Struct.IntField"},
+		"intPtrField":           []string{"field Struct.IntPtrField"},
+		"intTypedefField":       []string{"field Struct.IntTypedefField", "type IntType"},
+		"intTypedefPtrField":    []string{"field Struct.IntTypedefPtrField", "type IntType"},
+		"otherStructPtrField":   []string{"field Struct.OtherStructPtrField", "type OtherStruct"},
+		"sliceField":            []string{"field Struct.SliceField"},
+		"mapField":              []string{"field Struct.MapField"},
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
@@ -49,9 +49,23 @@ func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *fiel
 	return errs
 }
 
+func Validate_MapType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+	// type MapType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type MapType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_SliceType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+	// type SliceType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type SliceType")...)
 
 	return errs
 }
@@ -181,6 +195,18 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return
 		}(fldPath.Child("sliceField"), obj.SliceField, safe.Field(oldObj, func(oldObj *Struct) []string { return oldObj.SliceField }))...)
 
+	// field Struct.SliceTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj SliceType) (errs field.ErrorList) {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceTypedefField")...)
+			errs = append(errs, Validate_SliceType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("sliceTypedefField"), obj.SliceTypedefField, safe.Field(oldObj, func(oldObj *Struct) SliceType { return oldObj.SliceTypedefField }))...)
+
 	// field Struct.MapField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj map[string]string) (errs field.ErrorList) {
@@ -191,6 +217,18 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField")...)
 			return
 		}(fldPath.Child("mapField"), obj.MapField, safe.Field(oldObj, func(oldObj *Struct) map[string]string { return oldObj.MapField }))...)
+
+	// field Struct.MapTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj MapType) (errs field.ErrorList) {
+			if e := validate.RequiredMap(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField")...)
+			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("mapTypedefField"), obj.MapTypedefField, safe.Field(oldObj, func(oldObj *Struct) MapType { return oldObj.MapTypedefField }))...)
 
 	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
@@ -42,9 +42,23 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
+func Validate_IntType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+	// type IntType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type IntType")...)
+
+	return errs
+}
+
 func Validate_OtherStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) (errs field.ErrorList) {
 	// type OtherStruct
 	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type OtherStruct")...)
+
+	return errs
+}
+
+func Validate_StringType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+	// type StringType
+	errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type StringType")...)
 
 	return errs
 }
@@ -73,6 +87,76 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField")...)
 			return
 		}(fldPath.Child("stringPtrField"), obj.StringPtrField, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.StringPtrField }))...)
+
+	// field Struct.StringTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefField"), &obj.StringTypedefField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return &oldObj.StringTypedefField }))...)
+
+	// field Struct.StringTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StringType) (errs field.ErrorList) {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefPtrField")...)
+			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("stringTypedefPtrField"), obj.StringTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *StringType { return oldObj.StringTypedefPtrField }))...)
+
+	// field Struct.IntField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntField")...)
+			return
+		}(fldPath.Child("intField"), &obj.IntField, safe.Field(oldObj, func(oldObj *Struct) *int { return &oldObj.IntField }))...)
+
+	// field Struct.IntPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntPtrField")...)
+			return
+		}(fldPath.Child("intPtrField"), obj.IntPtrField, safe.Field(oldObj, func(oldObj *Struct) *int { return oldObj.IntPtrField }))...)
+
+	// field Struct.IntTypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefField"), &obj.IntTypedefField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return &oldObj.IntTypedefField }))...)
+
+	// field Struct.IntTypedefPtrField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *IntType) (errs field.ErrorList) {
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+				errs = append(errs, e...)
+				return // do not proceed
+			}
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefPtrField")...)
+			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("intTypedefPtrField"), obj.IntTypedefPtrField, safe.Field(oldObj, func(oldObj *Struct) *IntType { return oldObj.IntTypedefPtrField }))...)
 
 	// field Struct.OtherStructPtrField
 	errs = append(errs,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
@@ -46,28 +46,28 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.SP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("sp"), obj.SP, safe.Field(oldObj, func(oldObj *Struct) *string { return oldObj.SP }))...)
 
 	// field Struct.IP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("ip"), obj.IP, safe.Field(oldObj, func(oldObj *Struct) *int { return oldObj.IP }))...)
 
 	// field Struct.BP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("bp"), obj.BP, safe.Field(oldObj, func(oldObj *Struct) *bool { return oldObj.BP }))...)
 
 	// field Struct.FP
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("fp"), obj.FP, safe.Field(oldObj, func(oldObj *Struct) *float64 { return oldObj.FP }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
@@ -46,28 +46,28 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.S
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("s"), &obj.S, safe.Field(oldObj, func(oldObj *Struct) *string { return &oldObj.S }))...)
 
 	// field Struct.I
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("i"), &obj.I, safe.Field(oldObj, func(oldObj *Struct) *int { return &oldObj.I }))...)
 
 	// field Struct.B
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *bool) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("b"), &obj.B, safe.Field(oldObj, func(oldObj *Struct) *bool { return &oldObj.B }))...)
 
 	// field Struct.F
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *float64) (errs field.ErrorList) {
-			errs = append(errs, validate.Immutable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.ImmutableByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("f"), &obj.F, safe.Field(oldObj, func(oldObj *Struct) *float64 { return &oldObj.F }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -461,13 +461,10 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 	// This should only ever hit Struct and Alias types, since that is the only
 	// opportunity to have type-attached comments to process.
 	context := validators.Context{
-		Scope: validators.ScopeType,
-		Type:  t,
-		Path:  fldPath,
-	}
-	if t.Kind == types.Alias {
-		context.Parent = t
-		context.Type = t.Underlying
+		Scope:  validators.ScopeType,
+		Type:   t,
+		Parent: nil,
+		Path:   fldPath,
 	}
 	if validations, err := td.validator.ExtractValidations(context, t.CommentLines); err != nil {
 		return nil, fmt.Errorf("%v: %w", fldPath, err)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -50,6 +50,8 @@ func isNilableType(t *types.Type) bool {
 	return false
 }
 
+// realType returns the underlying type of a type, unwrapping aliases and
+// dropping pointerness.
 func realType(t *types.Type) *types.Type {
 	for {
 		if t.Kind == types.Alias {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -40,14 +40,20 @@ func getMemberByJSON(t *types.Type, jsonName string) *types.Member {
 
 // isNilableType returns true if the argument type can be compared to nil.
 func isNilableType(t *types.Type) bool {
-	for t.Kind == types.Alias {
-		t = t.Underlying
-	}
-	switch t.Kind {
+	switch unaliasType(t).Kind {
 	case types.Pointer, types.Map, types.Slice, types.Interface: // Note: Arrays are not nilable
 		return true
 	}
 	return false
+}
+
+// unaliasType returns the underlying type of the specified type if it is an
+// alias, otherwise returns the type itself.
+func unaliasType(t *types.Type) *types.Type {
+	for t.Kind == types.Alias {
+		t = t.Underlying
+	}
+	return t
 }
 
 // realType returns the underlying type of a type, unwrapping aliases and

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -168,6 +168,8 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, 
 		return Validations{}, fmt.Errorf("no field for JSON name %q", payload)
 	} else if k := realType(memb.Type).Kind; k != types.Builtin {
 		return Validations{}, fmt.Errorf("only primitive types can be list-map keys, not %s", k)
+	} else if isPointer(memb.Type) {
+		return Validations{}, fmt.Errorf("pointer types cannot be list-map keys")
 	} else {
 		fieldName = memb.Name
 	}
@@ -181,6 +183,16 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, 
 	// This tag doesn't generate any validations.  It just accumulates
 	// information for other tags to use.
 	return Validations{}, nil
+}
+
+func isPointer(t *types.Type) bool {
+	if t.Kind == types.Pointer {
+		return true
+	}
+	if t.Kind == types.Alias {
+		return isPointer(t.Underlying)
+	}
+	return false
 }
 
 func (lmktv listMapKeyTagValidator) Docs() TagDoc {
@@ -294,6 +306,8 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 			}
 			buf := strings.Builder{}
 			buf.WriteString("return ")
+			// Note: this does not handle pointer fields, which are not
+			// supposed to be used as listMap keys.
 			for i, fld := range listMap.keyFields {
 				if i > 0 {
 					buf.WriteString(" && ")

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -81,10 +81,9 @@ var (
 )
 
 func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// We don't support pointers to lists, but other validators use realType()
+	// for this sort of check, so let's be consistent.
+	t := realType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return Validations{}, fmt.Errorf("can only be used on list types")
 	}
@@ -93,18 +92,13 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 	case "atomic":
 		// Allowed but no special handling.
 	case "set":
-		t = t.Elem
 		// NOTE: lists of pointers are not supported, and that is enforced way before this point.
-		for t.Kind == types.Alias {
-			t = t.Underlying
-		}
-		switch {
-		case t.IsComparable():
+		if realType(t.Elem).IsComparable() {
 			return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUnique)}}, nil
-		case !t.IsComparable():
-			return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUniqueNonComparable)}}, nil
 		}
+		return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUniqueNonComparable)}}, nil
 	case "map":
+		// NOTE: maps of pointers are not supported, and that is enforced way before this point.
 		if realType(t.Elem).Kind != types.Struct {
 			return Validations{}, fmt.Errorf("only lists of structs can be list-maps")
 		}
@@ -152,10 +146,9 @@ func (listMapKeyTagValidator) ValidScopes() sets.Set[Scope] {
 }
 
 func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// We don't support pointers to lists, but other validators use realType()
+	// for this sort of check, so let's be consistent.
+	t := realType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return Validations{}, fmt.Errorf("can only be used on list types")
 	}
@@ -235,10 +228,9 @@ var (
 )
 
 func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// We don't support pointers to lists, but other validators use realType()
+	// for this sort of check, so let's be consistent.
+	t := realType(context.Type)
 	switch t.Kind {
 	case types.Slice, types.Array, types.Map:
 	default:
@@ -370,10 +362,9 @@ var (
 )
 
 func (ektv eachKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// We don't support pointers to lists, but other validators use realType()
+	// for this sort of check, so let's be consistent.
+	t := realType(context.Type)
 	if t.Kind != types.Map {
 		return Validations{}, fmt.Errorf("can only be used on map types")
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -81,9 +81,8 @@ var (
 )
 
 func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	// We don't support pointers to lists, but other validators use realType()
-	// for this sort of check, so let's be consistent.
-	t := realType(context.Type)
+	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
+	t := nativeType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return Validations{}, fmt.Errorf("can only be used on list types")
 	}
@@ -92,14 +91,14 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 	case "atomic":
 		// Allowed but no special handling.
 	case "set":
-		// NOTE: lists of pointers are not supported, and that is enforced way before this point.
-		if realType(t.Elem).IsComparable() {
+		// NOTE: lists of pointers are not supported, so we should never see a pointer here.
+		if nativeType(t.Elem).IsComparable() {
 			return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUnique)}}, nil
 		}
 		return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUniqueNonComparable)}}, nil
 	case "map":
-		// NOTE: maps of pointers are not supported, and that is enforced way before this point.
-		if realType(t.Elem).Kind != types.Struct {
+		// NOTE: maps of pointers are not supported, so we should never see a pointer here.
+		if nativeType(t.Elem).Kind != types.Struct {
 			return Validations{}, fmt.Errorf("only lists of structs can be list-maps")
 		}
 
@@ -146,23 +145,21 @@ func (listMapKeyTagValidator) ValidScopes() sets.Set[Scope] {
 }
 
 func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	// We don't support pointers to lists, but other validators use realType()
-	// for this sort of check, so let's be consistent.
-	t := realType(context.Type)
+	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
+	t := nativeType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return Validations{}, fmt.Errorf("can only be used on list types")
 	}
-	if realType(t.Elem).Kind != types.Struct {
+	// NOTE: lists of pointers are not supported, so we should never see a pointer here.
+	if nativeType(t.Elem).Kind != types.Struct {
 		return Validations{}, fmt.Errorf("only lists of structs can be list-maps")
 	}
 
 	var fieldName string
-	if memb := getMemberByJSON(realType(t.Elem), payload); memb == nil {
+	if memb := getMemberByJSON(nativeType(t.Elem), payload); memb == nil {
 		return Validations{}, fmt.Errorf("no field for JSON name %q", payload)
-	} else if k := realType(memb.Type).Kind; k != types.Builtin {
-		return Validations{}, fmt.Errorf("only primitive types can be list-map keys, not %s", k)
-	} else if isPointer(memb.Type) {
-		return Validations{}, fmt.Errorf("pointer types cannot be list-map keys")
+	} else if k := nativeType(memb.Type).Kind; k != types.Builtin {
+		return Validations{}, fmt.Errorf("only primitive types can be list-map keys (%s)", k)
 	} else {
 		fieldName = memb.Name
 	}
@@ -176,16 +173,6 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, 
 	// This tag doesn't generate any validations.  It just accumulates
 	// information for other tags to use.
 	return Validations{}, nil
-}
-
-func isPointer(t *types.Type) bool {
-	if t.Kind == types.Pointer {
-		return true
-	}
-	if t.Kind == types.Alias {
-		return isPointer(t.Underlying)
-	}
-	return false
 }
 
 func (lmktv listMapKeyTagValidator) Docs() TagDoc {
@@ -228,9 +215,8 @@ var (
 )
 
 func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	// We don't support pointers to lists, but other validators use realType()
-	// for this sort of check, so let's be consistent.
-	t := realType(context.Type)
+	// NOTE: pointers to lists and maps are not supported, so we should never see a pointer here.
+	t := nativeType(context.Type)
 	switch t.Kind {
 	case types.Slice, types.Array, types.Map:
 	default:
@@ -362,9 +348,8 @@ var (
 )
 
 func (ektv eachKeyTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	// We don't support pointers to lists, but other validators use realType()
-	// for this sort of check, so let's be consistent.
-	t := realType(context.Type)
+	// NOTE: pointers to lists are not supported, so we should never see a pointer here.
+	t := nativeType(context.Type)
 	if t.Kind != types.Map {
 		return Validations{}, fmt.Errorf("can only be used on map types")
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
@@ -60,10 +60,9 @@ var (
 var setsNew = types.Name{Package: "k8s.io/apimachinery/pkg/util/sets", Name: "New"}
 
 func (etv *enumTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
-	// We don't support typdefs to pointers, but other validators use
-	// realType() for this sort of check, so let's be consistent.
-	if realType(context.Type) != types.String {
-		return Validations{}, fmt.Errorf("can only be used on string types")
+	// NOTE: typedefs to pointers are not supported, so we should never see a pointer here.
+	if t := nativeType(context.Type); t != types.String {
+		return Validations{}, fmt.Errorf("can only be used on string types (%s)", rootTypeString(context.Type, t))
 	}
 
 	var result Validations

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -53,8 +53,8 @@ var (
 func (formatTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	// This tag can apply to value and pointer fields, as well as typedefs
 	// (which should never be pointers). We need to check the concrete type.
-	if realType(context.Type) != types.String {
-		return Validations{}, fmt.Errorf("can only be used on string types")
+	if t := nonPointer(nativeType(context.Type)); t != types.String {
+		return Validations{}, fmt.Errorf("can only be used on string types (%s)", rootTypeString(context.Type, t))
 	}
 
 	var result Validations

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -51,6 +51,12 @@ var (
 )
 
 func (formatTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+	// This tag can apply to value and pointer fields, as well as typedefs
+	// (which should never be pointers). We need to check the concrete type.
+	if realType(context.Type) != types.String {
+		return Validations{}, fmt.Errorf("can only be used on string types")
+	}
+
 	var result Validations
 	if formatFunction, err := getFormatValidationFunction(payload); err != nil {
 		return result, err

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -51,15 +51,8 @@ var (
 func (immutableTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
-	t := context.Type
-	for t.Kind == types.Pointer || t.Kind == types.Alias {
-		if t.Kind == types.Pointer {
-			t = t.Elem
-		} else if t.Kind == types.Alias {
-			t = t.Underlying
-		}
-	}
-	if t.IsComparable() {
+	if realType(context.Type).IsComparable() {
+		// Note: This compares the pointee, not the pointer itself.
 		result.AddFunction(Function(immutableTagName, DefaultFlags, immutableValidator))
 	} else {
 		result.AddFunction(Function(immutableTagName, DefaultFlags, immutableNonComparableValidator))

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -51,7 +51,7 @@ var (
 func (immutableTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
-	if realType(context.Type).Kind == types.Builtin {
+	if nonPointer(nativeType(context.Type)).Kind == types.Builtin {
 		// This is a minor optimization to just compare primitive values when
 		// possible. Slices and maps are not comparable, and structs might hold
 		// pointer fields, which are directly comparable but not what we need.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -113,10 +113,9 @@ var (
 func (maxItemsTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// We don't support pointers to lists, but other validators use realType()
+	// for this sort of check, so let's be consistent.
+	t := realType(context.Type)
 	if t.Kind != types.Slice && t.Kind != types.Array {
 		return result, fmt.Errorf("can only be used on list types (%s)", rootTypeString(context.Type, t))
 	}
@@ -168,6 +167,8 @@ var (
 func (minimumTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
+	// This tag can apply to value and pointer fields, as well as typedefs
+	// (which should never be pointers). We need to check the concrete type.
 	if t := realType(context.Type); !types.IsInteger(t) {
 		return result, fmt.Errorf("can only be used on integer types (%s)", rootTypeString(context.Type, t))
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -57,10 +57,9 @@ var (
 func (maxLengthTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
-	t := context.Type
-	if t.Kind == types.Alias {
-		t = t.Underlying
-	}
+	// This tag can apply to value and pointer fields, as well as typedefs
+	// (which should never be pointers). We need to check the concrete type.
+	t := realType(context.Type)
 	if t != types.String {
 		return result, fmt.Errorf("can only be used on string types (%s)", rootTypeString(context.Type, t))
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -90,7 +90,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	// originally defined as a value-type or a pointer-type in the API.  This
 	// one does.  Since Go doesn't do partial specialization of templates, we
 	// do manual dispatch here.
-	switch context.Type.Kind {
+	switch unaliasType(context.Type).Kind {
 	case types.Slice:
 		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
 	case types.Map:
@@ -161,7 +161,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	// originally defined as a value-type or a pointer-type in the API.  This
 	// one does.  Since Go doesn't do partial specialization of templates, we
 	// do manual dispatch here.
-	switch context.Type.Kind {
+	switch unaliasType(context.Type).Kind {
 	case types.Slice:
 		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
 	case types.Map:
@@ -261,7 +261,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	// optional check and short-circuit (but without error).  Why?  For
 	// example, this prevents any further validation from trying to run on a
 	// nil pointer.
-	switch context.Type.Kind {
+	switch unaliasType(context.Type).Kind {
 	case types.Slice:
 		return Validations{
 			Functions: []FunctionGen{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -90,7 +90,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	// originally defined as a value-type or a pointer-type in the API.  This
 	// one does.  Since Go doesn't do partial specialization of templates, we
 	// do manual dispatch here.
-	switch unaliasType(context.Type).Kind {
+	switch nativeType(context.Type).Kind {
 	case types.Slice:
 		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
 	case types.Map:
@@ -161,7 +161,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	// originally defined as a value-type or a pointer-type in the API.  This
 	// one does.  Since Go doesn't do partial specialization of templates, we
 	// do manual dispatch here.
-	switch unaliasType(context.Type).Kind {
+	switch nativeType(context.Type).Kind {
 	case types.Slice:
 		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalSliceValidator)}}, nil
 	case types.Map:
@@ -182,7 +182,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 // hasZeroDefault returns whether the field has a default value and whether
 // that default value is the zero value for the field's type.
 func (rtv requirednessTagValidator) hasZeroDefault(context Context) (bool, bool, error) {
-	t := realType(context.Type)
+	t := nonPointer(nativeType(context.Type))
 	// This validator only applies to fields, so Member must be valid.
 	tagsByName, err := gengo.ExtractFunctionStyleCommentTags("+", []string{defaultTagName}, context.Member.CommentLines)
 	if err != nil {
@@ -261,7 +261,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	// optional check and short-circuit (but without error).  Why?  For
 	// example, this prevents any further validation from trying to run on a
 	// nil pointer.
-	switch unaliasType(context.Type).Kind {
+	switch nativeType(context.Type).Kind {
 	case types.Slice:
 		return Validations{
 			Functions: []FunctionGen{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -65,9 +65,6 @@ func (requirednessTagValidator) ValidScopes() sets.Set[Scope] {
 }
 
 func (rtv requirednessTagValidator) GetValidations(context Context, _ []string, _ string) (Validations, error) {
-	if context.Type.Kind == types.Alias {
-		panic("alias type should already have been unwrapped")
-	}
 	switch rtv.mode {
 	case requirednessRequired:
 		return rtv.doRequired(context)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -56,7 +56,7 @@ var (
 func (stv subfieldTagValidator) GetValidations(context Context, args []string, payload string) (Validations, error) {
 	// This tag can apply to value and pointer fields, as well as typedefs
 	// (which should never be pointers). We need to check the concrete type.
-	t := realType(context.Type)
+	t := nonPointer(nativeType(context.Type))
 	if t.Kind != types.Struct {
 		return Validations{}, fmt.Errorf("can only be used on struct types")
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -54,6 +54,8 @@ var (
 )
 
 func (stv subfieldTagValidator) GetValidations(context Context, args []string, payload string) (Validations, error) {
+	// This tag can apply to value and pointer fields, as well as typedefs
+	// (which should never be pointers). We need to check the concrete type.
 	t := realType(context.Type)
 	if t.Kind != types.Struct {
 		return Validations{}, fmt.Errorf("can only be used on struct types")

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -57,8 +57,9 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 
 	// Gengo does not treat struct definitions as aliases, which is
 	// inconsistent but unlikely to change. That means we don't REALLY need to
-	// handle it here, but let's be consistent with the rest of the code.
-	if realType(context.Type).Kind != types.Struct {
+	// handle it here, but let's be extra careful and extract the most concrete
+	// type possible.
+	if nonPointer(nativeType(context.Type)).Kind != types.Struct {
 		return result, nil
 	}
 
@@ -125,8 +126,8 @@ func (unionDiscriminatorTagValidator) ValidScopes() sets.Set[Scope] {
 func (udtv unionDiscriminatorTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	// This tag can apply to value and pointer fields, as well as typedefs
 	// (which should never be pointers). We need to check the concrete type.
-	if realType(context.Type) != types.String {
-		return Validations{}, fmt.Errorf("can only be used on string types")
+	if t := nonPointer(nativeType(context.Type)); t != types.String {
+		return Validations{}, fmt.Errorf("can only be used on string types (%s)", rootTypeString(context.Type, t))
 	}
 
 	p := &discriminatorParams{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -120,6 +120,12 @@ func (unionDiscriminatorTagValidator) ValidScopes() sets.Set[Scope] {
 }
 
 func (udtv unionDiscriminatorTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
+	// This tag can apply to value and pointer fields, as well as typedefs
+	// (which should never be pointers). We need to check the concrete type.
+	if realType(context.Type) != types.String {
+		return Validations{}, fmt.Errorf("can only be used on string types")
+	}
+
 	p := &discriminatorParams{}
 	if len(payload) > 0 {
 		if err := json.Unmarshal([]byte(payload), &p); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -55,7 +55,10 @@ func (unionTypeValidator) Name() string {
 func (utv unionTypeValidator) GetValidations(context Context) (Validations, error) {
 	result := Validations{}
 
-	if context.Type.Kind != types.Struct {
+	// Gengo does not treat struct definitions as aliases, which is
+	// inconsistent but unlikely to change. That means we don't REALLY need to
+	// handle it here, but let's be consistent with the rest of the code.
+	if realType(context.Type).Kind != types.Struct {
 		return result, nil
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -133,25 +133,21 @@ type Context struct {
 	Scope Scope
 
 	// Type provides details about the type being validated.  When Scope is
-	// ScopeType, this is the underlying type.  When Scope is ScopeField, this
-	// is the field's type (including any pointerness).  When Scope indicates a
-	// list-value, map-key, or map-value, this is the type of that key or
-	// value.
+	// ScopeType, this is the newly defined type.  When Scope is ScopeField,
+	// this is the field's type (which may be a pointer, an alias, or both).
+	// When Scope indicates a list-value, map-key, or map-value, this is the
+	// type of that key or value (which, again, may be a pointer, and alias, or
+	// both).
 	Type *types.Type
 
-	// Parent provides details about the logical parent type of the type being
-	// validated, when applicable.  When Scope is ScopeType, this is the
-	// newly-defined type (when it exists - gengo handles struct-type
-	// definitions differently that other "alias" type definitions).  When
-	// Scope is ScopeField, this is the field's parent struct's type.  When
-	// Scope indicates a list-value, map-key, or map-value, this is the type of
-	// the whole list or map.
-	//
-	// Because of how gengo handles struct-type definitions, this field may be
-	// nil in those cases.
+	// Parent provides details about the logical parent type of the object
+	// being validated, when applicable.  When Scope is ScopeField, this is the
+	// containing struct's type.  When Scope indicates a list-value, map-key,
+	// or map-value, this is the type of the whole list or map. When Scope is
+	// ScopeType, this is nil.
 	Parent *types.Type
 
-	// Member provides details about a field within a struct, when Scope is
+	// Member provides details about a field within a struct when Scope is
 	// ScopeField.  For all other values of Scope, this will be nil.
 	Member *types.Member
 


### PR DESCRIPTION
The way we were handling (and testing) pointer and typedef fields was haphazard.

I went through each validator and added test cases where they were missing, and fixed implementations.

Then I changed how Context.Type is defined for typedefs. Previously Context.Type was the potentially aliased and potentially pointerful type for struct fields, but the "real" concrete type for typedefs.  Now it is consistent, and validators need to unalias and unpointer types (which they had to do anyway because it was inconsistent.

To emphasize: EVERY VALIDATOR MUST DECIDE HOW TO HANDLE ALIASES AND POINTERS.
 
Each commit in this PR should stand alone.

I should send this to k/k too.