### PR TITLE
WIP: What if chained tags didn't need "+k8s:"

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
@@ -87,22 +87,22 @@ type T1 struct {
 	OtherStructPtr *other.StructType `json:"otherStructPtr"`
 
 	// +k8s:validateTrue="field T1.SliceOfOtherStruct"
-	// +k8s:eachVal=+k8s:validateTrue="field T1.SliceOfOtherStruct values"
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=validateTrue="field T1.SliceOfOtherStruct values"
+	// +k8s:eachVal=opaqueType
 	SliceOfOtherStruct []other.StructType `json:"sliceOfOtherStruct"`
 
 	// +k8s:validateTrue="field T1.ListMapOfOtherStruct"
-	// +k8s:eachVal=+k8s:validateTrue="field T1.SliceOfOtherStruct values"
+	// +k8s:eachVal=validateTrue="field T1.SliceOfOtherStruct values"
 	// +k8s:listType=map
 	// +k8s:listMapKey=stringField
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=opaqueType
 	ListMapOfOtherStruct []other.StructType `json:"listMapOfOtherStruct"`
 
 	// +k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct"
-	// +k8s:eachKey=+k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct keys"
-	// +k8s:eachVal=+k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct values"
-	// +k8s:eachKey=+k8s:opaqueType
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachKey=validateTrue="field T1.MapOfOtherStringToOtherStruct keys"
+	// +k8s:eachVal=validateTrue="field T1.MapOfOtherStringToOtherStruct values"
+	// +k8s:eachKey=opaqueType
+	// +k8s:eachVal=opaqueType
 	MapOfOtherStringToOtherStruct map[other.StringType]other.StructType `json:"mapOfOtherStringToOtherStruct"`
 }
 
@@ -112,11 +112,11 @@ type T1 struct {
 
 /*
 // +k8s:validateTrue="type TypedefSliceOther"
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachVal=opaqueType
 type TypedefSliceOther []other.StructType
 
 // +k8s:validateTrue="type TypedefMapOther"
-// +k8s:eachKey=+k8s:opaqueType
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachKey=opaqueType
+// +k8s:eachVal=opaqueType
 type TypedefMapOther map[other.StringType]other.StructType
 */

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/keys/doc.go
@@ -30,23 +30,23 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.MapField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapField(keys)"
+	// +k8s:eachKey=validateFalse="field Struct.MapField(keys)"
 	MapField map[string]string `json:"mapField"`
 
 	// +k8s:validateFalse="field Struct.MapTypedefField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapTypedefField(keys)"
+	// +k8s:eachKey=validateFalse="field Struct.MapTypedefField(keys)"
 	MapTypedefField map[UnvalidatedStringType]string `json:"mapTypedefField"`
 
 	// +k8s:validateFalse="field Struct.MapValidatedTypedefField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapValidatedTypedefField(keys)"
+	// +k8s:eachKey=validateFalse="field Struct.MapValidatedTypedefField(keys)"
 	MapValidatedTypedefField map[ValidatedStringType]string `json:"mapValidatedTypedefField"`
 
 	// +k8s:validateFalse="field Struct.MapTypeField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapTypeField(keys)"
+	// +k8s:eachKey=validateFalse="field Struct.MapTypeField(keys)"
 	MapTypeField UnvalidatedMapType `json:"mapTypeField"`
 
 	// +k8s:validateFalse="field Struct.ValidatedMapTypeField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.ValidatedMapTypeField(keys)"
+	// +k8s:eachKey=validateFalse="field Struct.ValidatedMapTypeField(keys)"
 	ValidatedMapTypeField ValidatedMapType `json:"validatedMapTypeField"`
 }
 
@@ -60,5 +60,5 @@ type ValidatedStringType string
 type UnvalidatedMapType map[string]string
 
 // +k8s:validateFalse="ValidatedMapType"
-// +k8s:eachKey=+k8s:validateFalse="type ValidatedMapType(keys)"
+// +k8s:eachKey=validateFalse="type ValidatedMapType(keys)"
 type ValidatedMapType map[string]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_primitive/doc.go
@@ -30,11 +30,11 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.MapField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField map[string]string `json:"mapField"`
 
 	// +k8s:validateFalse="field Struct.MapTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField map[string]StringType `json:"mapTypedefField"`
 
 	UnvalidatedMapField map[string]string `json:"UnvalidatedMapField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/map_of_struct/doc.go
@@ -30,11 +30,11 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.MapField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField map[string]OtherStruct `json:"mapField"`
 
 	// +k8s:validateFalse="field Struct.MapTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField map[string]OtherTypedefStruct `json:"mapTypedefField"`
 
 	UnvalidatedMapField map[string]string `json:"UnvalidatedMapField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/multiple_validations/doc.go
@@ -31,10 +31,10 @@ type Struct struct {
 
 	// +k8s:validateFalse="field Struct.MapField #1"
 	// +k8s:validateFalse="field Struct.MapField #2"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapField(keys) #1"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapField(keys) #2"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*] #1"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*] #2"
+	// +k8s:eachKey=validateFalse="field Struct.MapField(keys) #1"
+	// +k8s:eachKey=validateFalse="field Struct.MapField(keys) #2"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*] #1"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*] #2"
 	MapField map[string]string `json:"mapField"`
 
 	UnvalidatedMapField []string `json:"UnvalidatedMapField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/maps/typedef_to_map/doc.go
@@ -29,7 +29,7 @@ var localSchemeBuilder = testscheme.New()
 type UnvalidatedType map[string]string
 
 // +k8s:validateFalse="type MapType"
-// +k8s:eachVal=+k8s:validateFalse="type MapType[*]"
+// +k8s:eachVal=validateFalse="type MapType[*]"
 type MapType map[string]string
 
 // Note: no validation here
@@ -39,7 +39,7 @@ type UnvalidatedPtrType map[string]*string
 type StringType string
 
 // +k8s:validateFalse="type MapTypedefType"
-// +k8s:eachVal=+k8s:validateFalse="type MapTypedefType[*]"
+// +k8s:eachVal=validateFalse="type MapTypedefType[*]"
 type MapTypedefType map[string]StringType
 
 // +k8s:validateFalse="type Struct"
@@ -47,10 +47,10 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.MapField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField MapType `json:"mapField"`
 
 	// +k8s:validateFalse="field Struct.MapTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField MapTypedefType `json:"mapTypedefField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/multiple_validations/doc.go
@@ -32,8 +32,8 @@ type Struct struct {
 
 	// +k8s:validateFalse="field Struct.ListField #1"
 	// +k8s:validateFalse="field Struct.ListField #2"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*] #1"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*] #2"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*] #1"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*] #2"
 	ListField []string `json:"listField"`
 
 	UnvalidatedListField []string `json:"UnvalidatedListField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_primitive/doc.go
@@ -30,11 +30,11 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.ListField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField []string `json:"listField"`
 
 	// +k8s:validateFalse="field Struct.ListTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField []StringType `json:"listTypedefField"`
 
 	UnvalidatedListField []string `json:"UnvalidatedListField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/slice_of_struct/doc.go
@@ -30,11 +30,11 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.ListField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField []OtherStruct `json:"listField"`
 
 	// +k8s:validateFalse="field Struct.ListTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 
 	UnvalidatedListField []OtherStruct `json:"UnvalidatedListField"`

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/slices/typedef_to_slice/doc.go
@@ -29,7 +29,7 @@ var localSchemeBuilder = testscheme.New()
 type UnvalidatedType []string
 
 // +k8s:validateFalse="type ListType"
-// +k8s:eachVal=+k8s:validateFalse="type ListType[*]"
+// +k8s:eachVal=validateFalse="type ListType[*]"
 type ListType []string
 
 // Note: no validation here
@@ -39,7 +39,7 @@ type UnvalidatedPtrType []*string
 type StringType string
 
 // +k8s:validateFalse="type ListTypedefType"
-// +k8s:eachVal=+k8s:validateFalse="type ListTypedefType[*]"
+// +k8s:eachVal=validateFalse="type ListTypedefType[*]"
 type ListTypedefType []StringType
 
 // +k8s:validateFalse="type Struct"
@@ -47,10 +47,10 @@ type Struct struct {
 	TypeMeta int
 
 	// +k8s:validateFalse="field Struct.ListField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField ListType `json:"listField"`
 
 	// +k8s:validateFalse="field Struct.ListTypedefField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField ListTypedefType `json:"listTypedefField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachkey/doc.go
@@ -27,19 +27,19 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachKey=+k8s:validateFalse="Struct.MapField(keys)"
+	// +k8s:eachKey=validateFalse="Struct.MapField(keys)"
 	MapField map[string]string `json:"mapField"`
 
-	// +k8s:eachKey=+k8s:validateFalse="Struct.MapTypedefField(keys)"
+	// +k8s:eachKey=validateFalse="Struct.MapTypedefField(keys)"
 	MapTypedefField map[UnvalidatedStringType]string `json:"mapTypedefField"`
 
-	// +k8s:eachKey=+k8s:validateFalse="Struct.MapValidatedTypedefField(keys)"
+	// +k8s:eachKey=validateFalse="Struct.MapValidatedTypedefField(keys)"
 	MapValidatedTypedefField map[ValidatedStringType]string `json:"mapValidatedTypedefField"`
 
-	// +k8s:eachKey=+k8s:validateFalse="Struct.MapTypeField(keys)"
+	// +k8s:eachKey=validateFalse="Struct.MapTypeField(keys)"
 	MapTypeField UnvalidatedMapType `json:"mapTypeField"`
 
-	// +k8s:eachKey=+k8s:validateFalse="Struct.ValidatedMapTypeField(keys)"
+	// +k8s:eachKey=validateFalse="Struct.ValidatedMapTypeField(keys)"
 	ValidatedMapTypeField ValidatedMapType `json:"validatedMapTypeField"`
 }
 
@@ -52,5 +52,5 @@ type ValidatedStringType string
 // Note: no validations.
 type UnvalidatedMapType map[string]string
 
-// +k8s:eachKey=+k8s:validateFalse="ValidatedMapType(keys)"
+// +k8s:eachKey=validateFalse="ValidatedMapType(keys)"
 type ValidatedMapType map[string]string

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_primitive/doc.go
@@ -27,10 +27,10 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField map[string]string `json:"mapField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField map[string]StringType `json:"mapTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/map_of_struct/doc.go
@@ -27,10 +27,10 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField map[string]OtherStruct `json:"mapField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField map[string]OtherTypedefStruct `json:"mapTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_primitive/doc.go
@@ -27,10 +27,10 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField []string `json:"listField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField []StringType `json:"listTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/slice_of_struct/doc.go
@@ -27,10 +27,10 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField []OtherStruct `json:"listField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_map/doc.go
@@ -27,7 +27,7 @@ var localSchemeBuilder = testscheme.New()
 // Note: no validation here
 type UnvalidatedType map[string]string
 
-// +k8s:eachVal=+k8s:validateFalse="type MapType[*]"
+// +k8s:eachVal=validateFalse="type MapType[*]"
 type MapType map[string]string
 
 // Note: no validation here
@@ -36,16 +36,16 @@ type UnvalidatedPtrType map[string]*string
 // +k8s:validateFalse="type StringType"
 type StringType string
 
-// +k8s:eachVal=+k8s:validateFalse="type MapTypedefType[*]"
+// +k8s:eachVal=validateFalse="type MapTypedefType[*]"
 type MapTypedefType map[string]StringType
 
 // +k8s:validateFalse="type Struct"
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapField[*]"
 	MapField MapType `json:"mapField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.MapTypedefField[*]"
 	MapTypedefField MapTypedefType `json:"mapTypedefField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/eachval/typedef_to_slice/doc.go
@@ -27,7 +27,7 @@ var localSchemeBuilder = testscheme.New()
 // Note: no validation here
 type UnvalidatedType []string
 
-// +k8s:eachVal=+k8s:validateFalse="type ListType[*]"
+// +k8s:eachVal=validateFalse="type ListType[*]"
 type ListType []string
 
 // Note: no validation here
@@ -35,15 +35,15 @@ type UnvalidatedPtrType []*string
 
 type StringType string
 
-// +k8s:eachVal=+k8s:validateFalse="type ListTypedefType[*]"
+// +k8s:eachVal=validateFalse="type ListTypedefType[*]"
 type ListTypedefType []StringType
 
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListField[*]"
 	ListField ListType `json:"listField"`
 
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListTypedefField[*]"
+	// +k8s:eachVal=validateFalse="field Struct.ListTypedefField[*]"
 	ListTypedefField ListTypedefType `json:"listTypedefField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
@@ -22,13 +22,6 @@ limitations under the License.
 package enum
 
 import (
-	context "context"
-
-	operation "k8s.io/apimachinery/pkg/api/operation"
-	safe "k8s.io/apimachinery/pkg/api/safe"
-	validate "k8s.io/apimachinery/pkg/api/validate"
-	sets "k8s.io/apimachinery/pkg/util/sets"
-	field "k8s.io/apimachinery/pkg/util/validation/field"
 	testscheme "k8s.io/code-generator/cmd/validation-gen/testscheme"
 )
 
@@ -37,85 +30,5 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
-	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
-		return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
-	})
 	return nil
-}
-
-var symbolsForEnum0 = sets.New[Enum0]()
-
-func Validate_Enum0(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
-	// type Enum0
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum0)...)
-
-	return errs
-}
-
-var symbolsForEnum1 = sets.New[Enum1](E1V1)
-
-func Validate_Enum1(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
-	// type Enum1
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum1)...)
-
-	return errs
-}
-
-var symbolsForEnum2 = sets.New[Enum2](E2V1, E2V2)
-
-func Validate_Enum2(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
-	// type Enum2
-	errs = append(errs, validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForEnum2)...)
-
-	return errs
-}
-
-func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
-	// field Struct.TypeMeta has no validation
-
-	// field Struct.Enum0Field
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum0(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum0Field"), &obj.Enum0Field, safe.Field(oldObj, func(oldObj *Struct) *Enum0 { return &oldObj.Enum0Field }))...)
-
-	// field Struct.Enum0PtrField
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum0) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum0(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum0PtrField"), obj.Enum0PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum0 { return oldObj.Enum0PtrField }))...)
-
-	// field Struct.Enum1Field
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum1(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum1Field"), &obj.Enum1Field, safe.Field(oldObj, func(oldObj *Struct) *Enum1 { return &oldObj.Enum1Field }))...)
-
-	// field Struct.Enum1PtrField
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum1) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum1(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum1PtrField"), obj.Enum1PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum1 { return oldObj.Enum1PtrField }))...)
-
-	// field Struct.Enum2Field
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum2(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum2Field"), &obj.Enum2Field, safe.Field(oldObj, func(oldObj *Struct) *Enum2 { return &oldObj.Enum2Field }))...)
-
-	// field Struct.Enum2PtrField
-	errs = append(errs,
-		func(fldPath *field.Path, obj, oldObj *Enum2) (errs field.ErrorList) {
-			errs = append(errs, Validate_Enum2(ctx, op, fldPath, obj, oldObj)...)
-			return
-		}(fldPath.Child("enum2PtrField"), obj.Enum2PtrField, safe.Field(oldObj, func(oldObj *Struct) *Enum2 { return oldObj.Enum2PtrField }))...)
-
-	// field Struct.NotEnumField has no validation
-	// field Struct.NotEnumPtrField has no validation
-	return errs
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
@@ -30,13 +30,13 @@ type Struct struct {
 	// +k8s:listType=map
 	// +k8s:listMapKey=key1Field
 	// +k8s:listMapKey=key2Field
-	// +k8s:eachVal=+k8s:immutable
+	// +k8s:eachVal=immutable
 	ListField []OtherStruct `json:"listField"`
 
 	// +k8s:listType=map
 	// +k8s:listMapKey=key1Field
 	// +k8s:listMapKey=key2Field
-	// +k8s:eachVal=+k8s:immutable
+	// +k8s:eachVal=immutable
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
@@ -29,12 +29,12 @@ type Struct struct {
 
 	// +k8s:listType=map
 	// +k8s:listMapKey=keyField
-	// +k8s:eachVal=+k8s:immutable
+	// +k8s:eachVal=immutable
 	ListField []OtherStruct `json:"listField"`
 
 	// +k8s:listType=map
 	// +k8s:listMapKey=keyField
-	// +k8s:eachVal=+k8s:immutable
+	// +k8s:eachVal=immutable
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -46,37 +46,37 @@ type Struct struct {
 	OpaqueStructPtrField *OtherStruct `json:"opaqueStructPtrField"`
 
 	// +k8s:validateFalse="field Struct.SliceOfStructField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.SliceOfStructField vals"
+	// +k8s:eachVal=validateFalse="field Struct.SliceOfStructField vals"
 	SliceOfStructField []OtherStruct `json:"sliceOfStructField"`
 
 	// +k8s:validateFalse="field Struct.SliceOfOpaqueStructField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.SliceOfOpaqueStructField vals"
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=validateFalse="field Struct.SliceOfOpaqueStructField vals"
+	// +k8s:eachVal=opaqueType
 	SliceOfOpaqueStructField []OtherStruct `json:"sliceOfOpaqueStructField"`
 
 	// +k8s:validateFalse="field Struct.ListMapOfStructField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListMapOfStructField vals"
+	// +k8s:eachVal=validateFalse="field Struct.ListMapOfStructField vals"
 	// +k8s:listType=map
 	// +k8s:listMapKey=stringField
 	ListMapOfStructField []OtherStruct `json:"listMapOfStructField"`
 
 	// +k8s:validateFalse="field Struct.ListMapOfOpaqueStructField"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListMapOfOpaqueStructField vals"
+	// +k8s:eachVal=validateFalse="field Struct.ListMapOfOpaqueStructField vals"
 	// +k8s:listType=map
 	// +k8s:listMapKey=stringField
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=opaqueType
 	ListMapOfOpaqueStructField []OtherStruct `json:"listMapOfOpaqueStructField"`
 
 	// +k8s:validateFalse="field Struct.MapOfStringToStructField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapOfStringToStructField keys"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapOfStringToStructField vals"
+	// +k8s:eachKey=validateFalse="field Struct.MapOfStringToStructField keys"
+	// +k8s:eachVal=validateFalse="field Struct.MapOfStringToStructField vals"
 	MapOfStringToStructField map[OtherString]OtherStruct `json:"mapOfStringToStructField"`
 
 	// +k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField"
-	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField keys"
-	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField vals"
-	// +k8s:eachKey=+k8s:opaqueType
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachKey=validateFalse="field Struct.MapOfStringToOpaqueStructField keys"
+	// +k8s:eachVal=validateFalse="field Struct.MapOfStringToOpaqueStructField vals"
+	// +k8s:eachKey=opaqueType
+	// +k8s:eachVal=opaqueType
 	MapOfStringToOpaqueStructField map[OtherString]OtherStruct `json:"mapOfStringToOpaqueStructField"`
 }
 
@@ -95,10 +95,10 @@ type OtherString string
 // +k8s:opaqueType.
 
 // +k8s:validateTrue="type TypedefSliceOther"
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachVal=opaqueType
 type TypedefSliceOther []OtherStruct
 
 // +k8s:validateTrue="type TypedefMapOther"
-// +k8s:eachKey=+k8s:opaqueType
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachKey=opaqueType
+// +k8s:eachVal=opaqueType
 type TypedefMapOther map[OtherString]OtherStruct

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/doc.go
@@ -27,19 +27,19 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:ifOptionEnabled(FeatureX)=+k8s:validateFalse="field Struct.XEnabledField"
+	// +k8s:ifOptionEnabled(FeatureX)=validateFalse="field Struct.XEnabledField"
 	XEnabledField string `json:"xEnabledField"`
 
-	// +k8s:ifOptionDisabled(FeatureX)=+k8s:validateFalse="field Struct.XDisabledField"
+	// +k8s:ifOptionDisabled(FeatureX)=validateFalse="field Struct.XDisabledField"
 	XDisabledField string `json:"xDisabledField"`
 
-	// +k8s:ifOptionEnabled(FeatureY)=+k8s:validateFalse="field Struct.YEnabledField"
+	// +k8s:ifOptionEnabled(FeatureY)=validateFalse="field Struct.YEnabledField"
 	YEnabledField string `json:"yEnabledField"`
 
-	// +k8s:ifOptionDisabled(FeatureY)=+k8s:validateFalse="field Struct.YDisabledField"
+	// +k8s:ifOptionDisabled(FeatureY)=validateFalse="field Struct.YDisabledField"
 	YDisabledField string `json:"yDisabledField"`
 
-	// +k8s:ifOptionEnabled(FeatureX)=+k8s:validateFalse="field Struct.XYMixedField/X"
-	// +k8s:ifOptionDisabled(FeatureY)=+k8s:validateFalse="field Struct.XYMixedField/Y"
+	// +k8s:ifOptionEnabled(FeatureX)=validateFalse="field Struct.XYMixedField/X"
+	// +k8s:ifOptionDisabled(FeatureY)=validateFalse="field Struct.XYMixedField/Y"
 	XYMixedField string `json:"xyMixedField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/doc.go
@@ -28,14 +28,14 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int `json:"typeMeta"`
 
-	// +k8s:subfield(structField)=+k8s:subfield(stringField)=+k8s:validateFalse="StructField.StructField"
-	// +k8s:subfield(sliceField)=+k8s:eachVal=+k8s:subfield(stringField)=+k8s:validateFalse="StructField.SliceField"
-	// +k8s:subfield(mapField)=+k8s:eachVal=+k8s:subfield(stringField)=+k8s:validateFalse="StructField.MapField"
+	// +k8s:subfield(structField)=subfield(stringField)=validateFalse="StructField.StructField"
+	// +k8s:subfield(sliceField)=eachVal=subfield(stringField)=validateFalse="StructField.SliceField"
+	// +k8s:subfield(mapField)=eachVal=subfield(stringField)=validateFalse="StructField.MapField"
 	StructField OtherStruct `json:"structField"`
 
-	// +k8s:subfield(structField)=+k8s:subfield(stringField)=+k8s:validateFalse="StructPtrField.StructField"
-	// +k8s:subfield(sliceField)=+k8s:eachVal=+k8s:subfield(stringField)=+k8s:validateFalse="StructPtrField.SliceField"
-	// +k8s:subfield(mapField)=+k8s:eachVal=+k8s:subfield(stringField)=+k8s:validateFalse="StructPtrField.MapField"
+	// +k8s:subfield(structField)=subfield(stringField)=validateFalse="StructPtrField.StructField"
+	// +k8s:subfield(sliceField)=eachVal=subfield(stringField)=validateFalse="StructPtrField.SliceField"
+	// +k8s:subfield(mapField)=eachVal=subfield(stringField)=validateFalse="StructPtrField.MapField"
 	StructPtrField *OtherStruct `json:"structPtrField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
@@ -28,7 +28,7 @@ import (
 var localSchemeBuilder = testscheme.New()
 
 type Struct struct {
-	// +k8s:subfield(stringField)=+k8s:validateFalse="subfield Struct.(other.StructType).StringField"
+	// +k8s:subfield(stringField)=validateFalse="subfield Struct.(other.StructType).StringField"
 	// +k8s:opaqueType
 	other.StructType
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc.go
@@ -28,18 +28,18 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int `json:"typeMeta"`
 
-	// +k8s:subfield(stringField)=+k8s:validateFalse="subfield Struct.StructField.StringField"
-	// +k8s:subfield(pointerField)=+k8s:validateFalse="subfield Struct.StructField.PointerField"
-	// +k8s:subfield(structField)=+k8s:validateFalse="subfield Struct.StructField.StructField"
-	// +k8s:subfield(sliceField)=+k8s:validateFalse="subfield Struct.StructField.SliceField"
-	// +k8s:subfield(mapField)=+k8s:validateFalse="subfield Struct.StructField.MapField"
+	// +k8s:subfield(stringField)=validateFalse="subfield Struct.StructField.StringField"
+	// +k8s:subfield(pointerField)=validateFalse="subfield Struct.StructField.PointerField"
+	// +k8s:subfield(structField)=validateFalse="subfield Struct.StructField.StructField"
+	// +k8s:subfield(sliceField)=validateFalse="subfield Struct.StructField.SliceField"
+	// +k8s:subfield(mapField)=validateFalse="subfield Struct.StructField.MapField"
 	StructField OtherStruct `json:"structField"`
 
-	// +k8s:subfield(stringField)=+k8s:validateFalse="subfield Struct.StructPtrField.StringField"
-	// +k8s:subfield(pointerField)=+k8s:validateFalse="subfield Struct.StructPtrField.PointerField"
-	// +k8s:subfield(structField)=+k8s:validateFalse="subfield Struct.StructPtrField.StructField"
-	// +k8s:subfield(sliceField)=+k8s:validateFalse="subfield Struct.StructPtrField.SliceField"
-	// +k8s:subfield(mapField)=+k8s:validateFalse="subfield Struct.StructPtrField.MapField"
+	// +k8s:subfield(stringField)=validateFalse="subfield Struct.StructPtrField.StringField"
+	// +k8s:subfield(pointerField)=validateFalse="subfield Struct.StructPtrField.PointerField"
+	// +k8s:subfield(structField)=validateFalse="subfield Struct.StructPtrField.StructField"
+	// +k8s:subfield(sliceField)=validateFalse="subfield Struct.StructPtrField.SliceField"
+	// +k8s:subfield(mapField)=validateFalse="subfield Struct.StructPtrField.MapField"
 	StructPtrField *OtherStruct `json:"structPtrField"`
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -469,7 +469,7 @@ func (td *typeDiscoverer) discover(t *types.Type, fldPath *field.Path) (*typeNod
 		context.Parent = t
 		context.Type = t.Underlying
 	}
-	if validations, err := td.validator.ExtractValidations(context, t.CommentLines); err != nil {
+	if validations, err := td.validator.ExtractValidations(context, "+k8s:", t.CommentLines); err != nil {
 		return nil, fmt.Errorf("%v: %w", fldPath, err)
 	} else if !validations.Empty() {
 		klog.V(5).InfoS("found type-attached validations", "n", validations.Len())
@@ -637,7 +637,7 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			Member: &memb,
 			Path:   childPath,
 		}
-		if validations, err := td.validator.ExtractValidations(context, memb.CommentLines); err != nil {
+		if validations, err := td.validator.ExtractValidations(context, "+k8s:", memb.CommentLines); err != nil {
 			return fmt.Errorf("field %s: %w", childPath.String(), err)
 		} else if !validations.Empty() {
 			klog.V(5).InfoS("found field-attached validations", "n", validations.Len())

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	listTypeTagName   = "k8s:listType"
-	ListMapKeyTagName = "k8s:listMapKey"
-	eachValTagName    = "k8s:eachVal"
-	eachKeyTagName    = "k8s:eachKey"
+	listTypeTagName   = "listType"
+	ListMapKeyTagName = "listMapKey"
+	eachValTagName    = "eachVal"
+	eachKeyTagName    = "eachKey"
 )
 
 // We keep the eachVal and eachKey validators around because the main
@@ -245,7 +245,7 @@ func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payl
 	case types.Map:
 		elemContext.Scope = ScopeMapVal
 	}
-	if validations, err := evtv.validator.ExtractValidations(elemContext, fakeComments); err != nil {
+	if validations, err := evtv.validator.ExtractValidations(elemContext, "", fakeComments); err != nil {
 		return Validations{}, err
 	} else {
 		if len(validations.Variables) > 0 {
@@ -371,7 +371,7 @@ func (ektv eachKeyTagValidator) GetValidations(context Context, _ []string, payl
 		Parent: t,
 		Path:   context.Path.Child("(keys)"),
 	}
-	if validations, err := ektv.validator.ExtractValidations(elemContext, fakeComments); err != nil {
+	if validations, err := ektv.validator.ExtractValidations(elemContext, "", fakeComments); err != nil {
 		return Validations{}, err
 	} else {
 		if len(validations.Variables) > 0 {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/gengo/v2/types"
 )
 
-const enumTagName = "k8s:enum"
+const enumTagName = "enum"
 
 func init() {
 	RegisterTagValidator(&enumTagValidator{})

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	formatTagName = "k8s:format"
+	formatTagName = "format"
 )
 
 func init() {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	immutableTagName = "k8s:immutable"
+	immutableTagName = "immutable"
 )
 
 func init() {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	maxLengthTagName = "k8s:maxLength"
-	maxItemsTagName  = "k8s:maxItems"
-	minimumTagName   = "k8s:minimum"
+	maxLengthTagName = "maxLength"
+	maxItemsTagName  = "maxItems"
+	minimumTagName   = "minimum"
 )
 
 func init() {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
@@ -19,7 +19,7 @@ package validators
 import "k8s.io/apimachinery/pkg/util/sets"
 
 const (
-	opaqueTypeTagName = "k8s:opaqueType"
+	opaqueTypeTagName = "opaqueType"
 )
 
 type opaqueTypeTagValidator struct{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/options.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	ifOptionEnabledTag  = "k8s:ifOptionEnabled"
-	ifOptionDisabledTag = "k8s:ifOptionDisabled"
+	ifOptionEnabledTag  = "ifOptionEnabled"
+	ifOptionDisabledTag = "ifOptionDisabled"
 )
 
 func init() {
@@ -63,7 +63,7 @@ func (iotv ifOptionTagValidator) GetValidations(context Context, args []string, 
 	result := Validations{}
 
 	fakeComments := []string{payload}
-	if validations, err := iotv.validator.ExtractValidations(context, fakeComments); err != nil {
+	if validations, err := iotv.validator.ExtractValidations(context, "", fakeComments); err != nil {
 		return Validations{}, err
 	} else {
 		for _, fn := range validations.Functions {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	requiredTagName  = "k8s:required"
-	optionalTagName  = "k8s:optional"
-	forbiddenTagName = "k8s:forbidden"
+	requiredTagName  = "required"
+	optionalTagName  = "optional"
+	forbiddenTagName = "forbidden"
 	defaultTagName   = "default" // TODO: this should evenually be +k8s:default
 )
 
@@ -101,7 +101,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	case types.Pointer:
 		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
 	case types.Struct:
-		// The +k8s:required tag on a non-pointer struct is not supported.
+		// The `required` tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
 		// for forbiddening a non-pointer struct, please let us know! We need
 		// to understand your scenario to determine if we need to adjust
@@ -172,7 +172,7 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	case types.Pointer:
 		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
 	case types.Struct:
-		// The +k8s:optional tag on a non-pointer struct is not supported.
+		// The `optional` tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
 		// for forbiddening a non-pointer struct, please let us know! We need
 		// to understand your scenario to determine if we need to adjust
@@ -287,7 +287,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 			},
 		}, nil
 	case types.Struct:
-		// The +k8s:forbidden tag on a non-pointer struct is not supported.
+		// The forbidden tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
 		// for forbiddening a non-pointer struct, please let us know! We need
 		// to understand your scenario to determine if we need to adjust

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	subfieldTagName = "k8s:subfield"
+	subfieldTagName = "subfield"
 )
 
 func init() {
@@ -76,7 +76,7 @@ func (stv subfieldTagValidator) GetValidations(context Context, args []string, p
 		Parent: t,
 		Path:   context.Path.Child(subname),
 	}
-	if validations, err := stv.validator.ExtractValidations(subContext, fakeComments); err != nil {
+	if validations, err := stv.validator.ExtractValidations(subContext, "", fakeComments); err != nil {
 		return Validations{}, err
 	} else {
 		if len(validations.Variables) > 0 {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -27,11 +27,11 @@ import (
 
 const (
 	// These tags return a fixed pass/fail state.
-	validateTrueTagName  = "k8s:validateTrue"
-	validateFalseTagName = "k8s:validateFalse"
+	validateTrueTagName  = "validateTrue"
+	validateFalseTagName = "validateFalse"
 
 	// This tag always returns an error from ExtractValidations.
-	validateErrorTagName = "k8s:validateError"
+	validateErrorTagName = "validateError"
 )
 
 func init() {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -98,8 +98,8 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 }
 
 const (
-	unionDiscriminatorTagName = "k8s:unionDiscriminator"
-	unionMemberTagName        = "k8s:unionMember"
+	unionDiscriminatorTagName = "unionDiscriminator"
+	unionMemberTagName        = "unionMember"
 )
 
 type unionDiscriminatorTagValidator struct {
@@ -227,7 +227,7 @@ func (umtv unionMemberTagValidator) Docs() TagDoc {
 }
 
 // discriminatorParams defines JSON the parameter value for the
-// +k8s:unionDiscriminator tag.
+// `unionDiscriminator` tag.
 type discriminatorParams struct {
 	// Union sets the name of the union this discriminator belongs to.
 	// This is only needed for go structs that contain more than one union.
@@ -235,7 +235,7 @@ type discriminatorParams struct {
 	Union string `json:"union,omitempty"`
 }
 
-// memberParams defines the JSON parameter value for the +k8s:unionMember tag.
+// memberParams defines the JSON parameter value for the `unionMember` tag.
 type memberParams struct {
 	// Union sets the name of the union this member belongs to.
 	// This is only needed for go structs that contain more than one union.
@@ -250,7 +250,7 @@ type memberParams struct {
 }
 
 // union defines how a union validation will be generated, based
-// on +k8s:unionMember and +k8s:unionDiscriminator tags found in a go struct.
+// on `unionMember` and `unionDiscriminator` tags found in a go struct.
 type union struct {
 	// fields provides field information about all the members of the union.
 	// Each slice element is a [2]string to provide a fieldName and memberName pair, where


### PR DESCRIPTION
This is just an idea - looking for feedback.  Better or worse?

In this model, the "+k8s:" is an indication that "the rest of this line is a k8s tag" - the tags themselves are named more simply.